### PR TITLE
本人情報確認ページ、左サイドバー設置

### DIFF
--- a/app/assets/stylesheets/modules/_user-identity.scss
+++ b/app/assets/stylesheets/modules/_user-identity.scss
@@ -2,13 +2,6 @@
   .user-identity__area {
     margin: 40px auto;
     width: 1020px;
-    &--side-menu {
-      @include f-left;
-      width: 280px;
-      height: 1252px;
-      background: white;
-      margin-right: 40px;
-    }
     &--profile {
       @include f-right;
       background: #fff;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
- layout  "session", except: [:index]
+ layout  "session", except: [:index, :show]
 # ログイン画面への遷移)(仮)
   def new
   end
@@ -11,11 +11,11 @@ class UsersController < ApplicationController
 # ユーザーの新規登録画面(仮)
   def registration
   end
-  
+
   def index
 
   end
-  
+
   def show
   end
 end

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -83,8 +83,4 @@
               %p
                 本人情報の登録について
                 = fa_icon("angle-right")
-    // テンプレート呼び出しサイドバー(仮置き)
-    // マイページ担当者で部分テンプレートを作成し参照。
-    // = render partial: ""
-    .user-identity__area--side-menu
-      ※マイページ担当者作成部分テンプレート反映予定
+    = render partial: 'user_side_bar'


### PR DESCRIPTION
# WHAT
本人確認ページ左側の仮置きメニューを、テンプレート呼び出しに変更する。

# WHY
仮置き状態のdiv枠を本来の状態にするため。