### PR TITLE
商品購入確認ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "modules/registration";
 @import "modules/registration-select";
 @import "modules/exhibit";
+@import "modules/buy-check";
 @import "users";
 @import "user_side_bar";
 

--- a/app/assets/stylesheets/modules/_buy-check.scss
+++ b/app/assets/stylesheets/modules/_buy-check.scss
@@ -1,0 +1,153 @@
+.exhibit-check {
+  &__container {
+    &--header {
+      height: 128px;
+      text-align: center;
+      h1 {
+        margin: 40px 0 0;
+        display: inline-block;
+        .mercari-image {
+          width: 185px;
+          height: 49px;
+        }
+      }
+    }
+    &--main {
+      background: #fff;
+      width: 700px;
+      margin: 0 auto;
+      .buy-item {
+        display: block;
+        &:first-child {
+          text-align: center;
+        }
+        h2 {
+          padding: 32px 16px;
+          font-weight: bold;
+          font-size: 22px;
+        }
+        &__info {
+          width: 320px;
+          margin: 0 auto;
+          margin-bottom: 40px;
+          &--image {
+            border-top: 1px solid #f5f5f5;
+            padding-top: 24px;
+            .buy-item-image {
+              max-height: 148px;
+            }
+          }
+          &--name {
+           margin-top: 8px;
+            font-size: 16px;
+            line-height: 1.5;
+          }
+          &--form {
+            .bold{
+              font-weight: 600;
+            }
+            .buy-price {
+              font-size: 28px;
+              margin-top: 8px;
+              &__tax {
+                margin-left: 8px;
+                font-size: 14px;
+                font-weight: 400;
+              }
+            }
+            .buy-accordion {
+              margin-top: 16px;
+              &__list {
+                border: 1px solid #ccc;
+                padding: 16px;
+                height: 14px;
+              }
+            }
+          }
+          .buy-price-table {
+            height: 60px;
+            &__cell {
+              padding: 16px 0;
+              @include f-left;
+              font-weight: 600;
+              font-size: 28px;
+              &:last-child {
+                @include f-right;
+              }
+            }
+          }
+          .buy-has-text {
+            margin-top: 8px;
+            color: #f00;
+          }
+          .buy-button {
+            margin-top: 16px;
+            background: #ccc;
+            height: 48px;
+            line-height: 48px;
+          }
+          .buy-app-button {
+            margin-top: 8px;
+            &__image {
+              margin-top: 16px;
+              .logo-image {
+                height: 43px;
+              }
+            }
+          }
+        }
+        &__delivery {
+          border-top: 1px solid #eee;
+          padding: 40px;
+          .delivery-box {
+            text-align: left;
+            max-width: 320px;
+            margin: 0 auto;
+            &__title {
+              font-weight: bold;
+            }
+            &__main {
+              margin-top: 8px;
+            }
+            &__input {
+              color: #0099e8;
+              text-align: right;
+              .fa-angle-right {
+                padding-left: 8px;
+              }
+            }
+          }
+        }
+      }
+    }
+    &--footer {
+      padding: 40px 0;
+      text-align: center;
+      .footer-content{
+        &__rule-link {
+          li {
+            display: inline-block;
+            margin: 0 16px 0 0;
+          }
+          &--agreement {
+            display: block;
+            color: #333;
+          }
+        }
+        &__mercari-footer-logo {
+          display: block;
+          color: #333;
+          width: 80px;
+          height: 65px;
+          margin: 40px auto 0;
+        }
+        &__copyright {
+          margin: 8px 0 0;
+          &--content{
+            font-size: 12px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_buy-check.scss
+++ b/app/assets/stylesheets/modules/_buy-check.scss
@@ -38,12 +38,12 @@
             }
           }
           &--name {
-           margin-top: 8px;
+            margin-top: 8px;
             font-size: 16px;
             line-height: 1.5;
           }
           &--form {
-            .bold{
+            .bold {
               font-weight: 600;
             }
             .buy-price {
@@ -123,7 +123,7 @@
     &--footer {
       padding: 40px 0;
       text-align: center;
-      .footer-content{
+      .footer-content {
         &__rule-link {
           li {
             display: inline-block;
@@ -143,7 +143,7 @@
         }
         &__copyright {
           margin: 8px 0 0;
-          &--content{
+          &--content {
             font-size: 12px;
           }
         }

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -1,4 +1,8 @@
 class CreditsController < ApplicationController
+  layout  "session", only: [:index]
   def new
+  end
+
+  def index
   end
 end

--- a/app/views/credits/index.haml
+++ b/app/views/credits/index.haml
@@ -1,0 +1,79 @@
+.exhibit-check
+  .exhibit-check__container
+    %header.exhibit-check__container--header
+      %h1
+        = link_to '' do
+          = image_tag("logo/logo.svg", class: "mercari-image", alt: "mercari")
+    .exhibit-check__container--main
+      %selection.buy-item
+        %h2
+          購入を確定しますか？
+        .buy-item__info
+          %h3.buy-item__info--image
+            = image_tag("tmp/m53316857133_1.jpg",class: "buy-item-image")
+          %p.buy-item__info--name
+            NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME
+          %form.buy-item__info--form
+            %p.buy-price.bold
+              ¥ 9,980
+              %span.buy-price__tax
+                送料込み
+            .buy-accordion
+              .buy-accordion__list
+                ポイントを使う
+                = fa_icon("angle-down")
+            .buy-price-table
+              .buy-price-table__cell
+                支払い金額
+              .buy-price-table__cell
+                ¥ 9,980
+            %p.buy-has-text
+              この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
+            .buy-button
+              購入する
+            %p.buy-app-button
+              アプリをお持ちでない方は以下よりインストールしてご利用いただけます。
+              .buy-app-button__image
+                = link_to "" do
+                  = image_tag("logo/app-store.svg", class: "logo-image")
+                = link_to "" do
+                  = image_tag("logo/google-play.svg", class: "logo-image")
+        .buy-item__delivery
+          .delivery-box
+            %h3.delivery-box__title
+              配送先
+            %p.delivery-box__main
+              〒000-0000
+              %br
+              大阪府 大阪市中央区 中央町0-0-0
+              %br
+              あい うえお
+            = link_to "", class: "delivery-box__input" do
+              %p
+                変更する
+                = fa_icon("angle-right")
+        .buy-item__delivery
+          .delivery-box
+            %h3.delivery-box__title
+              支払い方法
+            %p.delivery-box__main
+              %br
+                \/
+            = link_to "", class: "delivery-box__input" do
+              %p
+                変更する
+                = fa_icon("angle-right")
+    %footer.exhibit-check__container--footer
+      .footer-content
+        %nav.footer-content__rule-link
+          %ul.clearfix
+            %li
+              = link_to 'プライバシーポリシー', '' ,class:'footer-content__rule-link--agreement'
+            %li
+              = link_to 'メルカリ利用規約','',class:'footer-content__rule-link--agreement'
+            %li
+              =link_to '特定商取引に関する表記','',class:'footer-content__rule-link--agreement'
+        = link_to '',class:'footer-content__mercari-footer-logo' do
+          = image_tag("logo/logo-gray.svg")
+        %p.footer-content__copyright
+          %small.footer-content__copyright--content © 2019 Mercari

--- a/app/views/credits/index.haml
+++ b/app/views/credits/index.haml
@@ -10,7 +10,7 @@
           購入を確定しますか？
         .buy-item__info
           %h3.buy-item__info--image
-            = image_tag("tmp/m53316857133_1.jpg",class: "buy-item-image")
+            = image_tag("tmp/m53316857133_1.jpg", class: "buy-item-image")
           %p.buy-item__info--name
             NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME-NAME
           %form.buy-item__info--form


### PR DESCRIPTION
# WHAT
商品購入確認ページをマークアップする。

stylesheets/application.scss
_buy-check.scssをインポートする設定を追加

controllers/credits_controller.rb
index.hamlを表示させる為のアクションを追加

credits/index.haml
商品購入確認ページの作成

stylesheets/modules/_buy-check.scss
商品購入確認ページのレイアウトを設定

# WHY
商品購入確認ページのマークアップを実施しました。
画像ファイルについては、他のマークアップページ作成でデータがあがっていますので、そちらを参照するように作成しました。
配送先、支払い方法についてはデザインが同一と考え、クラス名をあわせることにしました。

<img width="1440" alt="2019-02-04 18 17 59" src="https://user-images.githubusercontent.com/45278393/52199412-58729880-28a9-11e9-8f74-d57ec52cc11e.png">
<img width="1440" alt="2019-02-04 18 18 01" src="https://user-images.githubusercontent.com/45278393/52199420-5d374c80-28a9-11e9-9838-3ba02e2b6d5e.png">
