### PR TITLE
クレジットカードページ、Formメソッド名削除

### DIFF
--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -2,7 +2,7 @@
   %section.credit-content__during.clearfix
     .credit-form
       %h2.credit-form__title クレジットカード情報入力
-      %form.credit-form__form{action: "", "data-adyen-id": "card-form", method: "POST", novalidate: "novalidate"}
+      %form.credit-form__form
         .card-form
           .card-form__box
             %label.card-form__box--label カード番号


### PR DESCRIPTION
# WHAT
クレジットカードページのmethodを削除する

# WHY
仮置きフォームである為、メソッドの記述は不要である。
また、後ほどヘルパーメソッドで記述する為。

デプロイ環境で画面表示がされない原因と考えられるため。