### PR TITLE
クレジットカード情報ページ画像修正

### DIFF
--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -22,7 +22,7 @@
               %li
                 = image_tag("american_express.svg",class: "american_express")
               %li
-                = image_tag("dinersclub",class: "dinersclub")
+                = image_tag("dinersclub.svg",class: "dinersclub")
               %li
                 = image_tag("discover.svg",class: "discover")
           .card-form__box


### PR DESCRIPTION
# WHAT
画像ファイルの拡張子修正

# WHY
正常な状態ではなく、デプロイ環境でエラー状態となるため