### PR TITLE
ルーティング、コントローラー記述の修正

### DIFF
--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -1,28 +1,25 @@
 class CreditsController < ApplicationController
   layout  "session", only: [:index]
   before_action :item_set, only: [:create]
-   def new
+  def index
+  end
 
-   end
-   
-   def index
-   
-   end
+  def new
+  end
 
-   def create
-      price = item.price 
-      Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
-      charge = Payjp::Charge.create(
+  def create
+  price = item.price
+  Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+  charge = Payjp::Charge.create(
+    amount: price,
+    card: params['payjp-token'],
+    currency: 'jpy',
+  )
+  end
 
-         amount: price,
-         card:  params['payjp-token'],
-         currency: 'jpy',
-      )
-   end
+  private
 
-   private
-
-   def item_set
-     item = Item.find(params[:id])
-   end
+  def item_set
+   item = Item.find(params[:id])
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,5 @@
 class ItemsController < ApplicationController
   layout  "session", except: [:index, :show]
-  # トップページ作成でindex利用
   def index
   end
 
@@ -21,7 +20,7 @@ class ItemsController < ApplicationController
   def update
   end
 
-
+  private
   def item_params
     params.require(:item).permit(:name, :price,:description, :category_id,:buyer_id, :saler_id, :shipping_date_id,:condition_id,:region_id, :delivery_fee_id, :ship_method_id, :brand_id,:size_id, :transaction)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,15 @@
 class UsersController < ApplicationController
  layout  "session", except: [:index, :show, :edit, :logout]
-# ログイン画面への遷移)(仮)
-  def new
-  end
-
   def index
   end
 
-  def show
+  def new
   end
 
   def edit
+  end
+
+  def show
   end
 
   def logout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,10 @@ Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
   get "users/logout" => "users#logout"
-  resources :items
-  resources :users
-  resources :regions
-  resources :brands
-  resources :categorys
-  resources :credits
+  resources :items, except: [:edit, :destroy]
+  resources :users, only: [:index, :new, :edit, :show]
+  # resources :regions
+  # resources :brands
+  # resources :categorys
+  resources :credits, only: [:index, :new, :create]
 end


### PR DESCRIPTION
# WHAT

## コントローラー
7つのアクションの記述順序がバラバラであるため、慣習的な順序に変更する。

## ルーティング
マークアップ時に全ルート利用としていたが、マークアップが終了しているため、必要なルートのみに絞り込みを行い、不要ルートを削除する。

# WHY
不要リソースの削減及び可読性向上の為。