### PR TITLE
N+1問題のターミナル視認設定

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
+
 end


### PR DESCRIPTION
# WHAT
開発環境でN+1発見時にターミナルで確認できるように設定を追加する。

# WHY
見落としがちなN+1問題をターミナルで視認する為。