### PR TITLE
サインインページ、バリデーション設定・エラーメッセージ表示

### DIFF
--- a/app/assets/stylesheets/modules/_registration.scss
+++ b/app/assets/stylesheets/modules/_registration.scss
@@ -38,10 +38,12 @@
             margin: 0;
           }
           label {
+            @include f-left;
             font-weight: 600;
             display: inline-block;
           }
           .require-tag {
+            @include f-left;
             background-color: #ea352d;
             margin: 0 0 0 8px;
             padding: 2px 4px;
@@ -74,6 +76,18 @@
               display: inline-block;
               position: relative;
               margin: 8px 0 0;
+              width: 200px;
+              .field_with_errors {
+                #user_birthday_1i {
+                  border: 1px solid red;
+                }
+                #user_birthday_2i {
+                  border: 1px solid red;
+                }
+                #user_birthday_3i {
+                  border: 1px solid red;
+                }
+              }
               #user_birthday_1i {
                 margin-top: 5px;
                 width: 140px;
@@ -115,6 +129,12 @@
                 font-size: 16px;
                 line-height: 1.5;
                 cursor: pointer;
+              }
+              #user_birthday_4i {
+                display: none;
+              }
+              #user_birthday_5i {
+                display: none;
               }
               &__default {
                 width: 140px;
@@ -182,6 +202,15 @@
             text-align: center;
             .link {
               color: #0099e8;
+            }
+          }
+          .error-msg {
+            color: red;
+            margin-top: 8px;
+          }
+          .field_with_errors {
+            input {
+              border: 1px solid red;
             }
           }
         }

--- a/app/assets/stylesheets/modules/_registration.scss
+++ b/app/assets/stylesheets/modules/_registration.scss
@@ -78,17 +78,11 @@
               margin: 8px 0 0;
               width: 200px;
               .field_with_errors {
-                #user_birthday_1i {
-                  border: 1px solid red;
-                }
-                #user_birthday_2i {
-                  border: 1px solid red;
-                }
-                #user_birthday_3i {
+                .birthday {
                   border: 1px solid red;
                 }
               }
-              #user_birthday_1i {
+              .birthday {
                 margin-top: 5px;
                 width: 140px;
                 position: relative;
@@ -101,40 +95,12 @@
                 font-size: 16px;
                 line-height: 1.5;
                 cursor: pointer;
-              }
-              #user_birthday_2i {
-                margin-top: 5px;
-                width: 140px;
-                position: relative;
-                z-index: 2;
-                height: 48px;
-                padding: 0 16px;
-                border-radius: 4px;
-                border: 1px solid #ccc;
-                background: 0;
-                font-size: 16px;
-                line-height: 1.5;
-                cursor: pointer;
-              }
-              #user_birthday_3i {
-                margin-top: 5px;
-                width: 140px;
-                position: relative;
-                z-index: 2;
-                height: 48px;
-                padding: 0 16px;
-                border-radius: 4px;
-                border: 1px solid #ccc;
-                background: 0;
-                font-size: 16px;
-                line-height: 1.5;
-                cursor: pointer;
-              }
-              #user_birthday_4i {
-                display: none;
-              }
-              #user_birthday_5i {
-                display: none;
+                &:nth-child(4){
+                  display: none;
+                }
+                &:nth-child(5){
+                  display: none;
+                }
               }
               &__default {
                 width: 140px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,18 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  layout :layout_by_resource
+
+  protected
+
+  def layout_by_resource
+    if devise_controller?
+      "session"
+    else
+      "application"
+    end
+  end
+
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,12 @@ class User < ApplicationRecord
   has_many :scores
   has_many :likes
   has_many :items
+  validates :nickname, presence: true
+  validates :encrypted_password, presence: true
+  validates :last_name, presence: true
+  validates :first_name, presence: true
+  validates :last_name_kana, presence: true
+  validates :first_name_kana, presence: true
+  validates :password, length: { in: 6..128 }
+  validates :birthday, presence: true
 end

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -92,7 +92,7 @@
           .birthday-select
             .select-wrap
               / = raw sprintf(form.date_select(:birthday, use_month_numbers: true, date_separator: '%s', start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'),"年","月")  + "日"
-              = raw sprintf(form.datetime_select(:birthday, use_month_numbers: true, date_separator: '%s', datetime_separator: '%s', time_separator: '',  start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'),"年","月","日")
+              = raw sprintf(form.datetime_select(:birthday, {use_month_numbers: true, date_separator: '%s', datetime_separator: '%s', time_separator: '',  start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'},{class: "birthday"}),"年","月","日")
               = fa_icon "angle-down", class: "angle-down", id: "down1"
               = fa_icon "angle-down", class: "angle-down", id: "down2"
               = fa_icon "angle-down", class: "angle-down", id: "down3"

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -91,7 +91,6 @@
           %span.require-tag 必須
           .birthday-select
             .select-wrap
-              / = raw sprintf(form.date_select(:birthday, use_month_numbers: true, date_separator: '%s', start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'),"年","月")  + "日"
               = raw sprintf(form.datetime_select(:birthday, {use_month_numbers: true, date_separator: '%s', datetime_separator: '%s', time_separator: '',  start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'},{class: "birthday"}),"年","月","日")
               = fa_icon "angle-down", class: "angle-down", id: "down1"
               = fa_icon "angle-down", class: "angle-down", id: "down2"

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -1,6 +1,6 @@
 .registration
   %header.registration__header
-    = link_to "", class: "logo" do
+    = link_to root_path, class: "logo" do
       = image_tag "logo/logo.svg", class: "top-logo"
     %nav.progress-bar
       %ol.clearfix
@@ -28,18 +28,33 @@
           = form.label :nickname
           %span.require-tag 必須
           = form.text_field :nickname, autofocus: true, placeholder: "例) メルカリ太郎",class: "field"
+          - @user.errors.full_messages_for(:nickname).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :email
           %span.require-tag 必須
           = form.email_field :email, placeholder: "PC・携帯どちらでも可",class: "field"
+          - @user.errors.full_messages_for(:email).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :password
           %span.require-tag 必須
           = form.password_field :password, placeholder: "6文字以上",class: "field"
+          - @user.errors.full_messages_for(:password).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :password_confirmation
           %span.require-tag 必須
           = form.password_field :password_confirmation, placeholder: "6文字以上",class: "field"
+          - @user.errors.full_messages_for(:encrypted_password).each do |error|
+            .span.error-msg
+              = error
+          - @user.errors.full_messages_for(:password_confirmation).each do |error|
+            .span.error-msg
+              = error
         .form-group
           %h2 本人確認
           %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
@@ -47,27 +62,44 @@
           = form.label :last_name
           %span.require-tag 必須
           = form.text_field :last_name, autofocus: true, placeholder: "例) 山田",class: "field"
+          - @user.errors.full_messages_for(:last_name).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :first_name
           %span.require-tag 必須
           = form.text_field :first_name, autofocus: true, placeholder: "例) 彩",class: "field"
+          - @user.errors.full_messages_for(:first_name).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :last_name_kana
           %span.require-tag 必須
           = form.text_field :last_name_kana, autofocus: true, placeholder: "例) ヤマダ",class: "field"
+          - @user.errors.full_messages_for(:last_name_kana).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :first_name_kana
           %span.require-tag 必須
           = form.text_field :first_name_kana, autofocus: true, placeholder: "例) アヤ",class: "field"
+          - @user.errors.full_messages_for(:first_name_kana).each do |error|
+            .span.error-msg
+              = error
         .form-group
           = form.label :birthday
           %span.require-tag 必須
           .birthday-select
             .select-wrap
-              = raw sprintf(form.date_select(:birthday, use_month_numbers: true, date_separator: '%s', start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date),"年","月") + "日"
+              / = raw sprintf(form.date_select(:birthday, use_month_numbers: true, date_separator: '%s', start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'),"年","月")  + "日"
+              = raw sprintf(form.datetime_select(:birthday, use_month_numbers: true, date_separator: '%s', datetime_separator: '%s', time_separator: '',  start_year: 1900, end_year: Time.now.year, default: '1900-1-1'.to_date, include_blank: '--'),"年","月","日")
               = fa_icon "angle-down", class: "angle-down", id: "down1"
               = fa_icon "angle-down", class: "angle-down", id: "down2"
               = fa_icon "angle-down", class: "angle-down", id: "down3"
+            - @user.errors.full_messages_for(:birthday).each do |error|
+              .span.error-msg
+                = error
+
         %p.form-group__info
           ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
       .content

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1215,7 +1215,6 @@ ja:
         otherwise_125: 'その他'
         otherwise_126: 'その他'
         category_list: 'カテゴリー一覧'
-
     condition:
       type:
         new_item: '新品、未使用'
@@ -1343,6 +1342,9 @@ ja:
         kids_shoes_16: '16cm・16.5cm'
         kids_shoes_17: '17cm以上'
   activerecord:
+    attributes:
+      user:
+        encrypted_password: パスワード (確認)
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'


### PR DESCRIPTION
# WHAT
サインインページにて、バリデーション設定及び入力漏れなどで表示されるエラーメッセージ表示を実装。

### バリデーション設定を追加
app/models/user.rb
### レイアウト適用ファイルを変更
app/controllers/application_controller.rb
### エラーメッセージ表示機能を追加
app/views/devise/registrations/new.haml
### エラー表示のスタイルを追加
app/assets/stylesheets/modules/_registration.scss
### 日本語化表記の追加
config/locales/ja.yml

# WHY
サインインページのエラー表示機能を実装しました。
・エラー表示の際にクラス名"field_with_errors"が付与されていましたので、こちらにinputフィールドborderを赤に変更する形にしました。
・birthdayについては、selectタグ指定で色変更しようとしましたが、できなかった為、個別のidに対して枠色変更する形にしました。
・パスワード確認用のエラーメッセージは英語表記のままでしたので、日本語化ファイルに記述を追加して対応しています。

## 表示崩れ対応について(2点あり)
# 1.必須ラベルについて
エラー表示前はラベルの左側に必須ラベルが表示されていましたが、エラー画面遷移時に表示が崩れました。
そのため、float処理を加えることで解消しました。
下記画像参照

## 修正前
![default](https://user-images.githubusercontent.com/45278393/52559336-68095880-2e38-11e9-9eb0-4819057345c4.png)
## 修正後
![default](https://user-images.githubusercontent.com/45278393/52559335-68095880-2e38-11e9-97e3-98b160e266f8.png)



# 2.生年月日セレクタについて
app/views/devise/registrations/new.hamlのコード、94,95行目が対象となります。
(修正前コードを確認して頂くために94行目をコメントアウトで残しています。)
1件目のラベル同様にエラー表示時に型崩れしました。

下記画像参照、詳細は画像の下へ記述しています。

## 修正前
### ビュー
![default](https://user-images.githubusercontent.com/45278393/52559677-4eb4dc00-2e39-11e9-814c-a5df79b9057b.png)
### デベロッパーツール(divの外に"日"が出ている)
![default](https://user-images.githubusercontent.com/45278393/52559676-4eb4dc00-2e39-11e9-88ac-5b8a42bfab97.png)

## 修正後
### ビュー
![default](https://user-images.githubusercontent.com/45278393/52559730-7310b880-2e39-11e9-821b-e8b01439e707.png)
### デベロッパーツール(divの中に"日"を格納)
![default](https://user-images.githubusercontent.com/45278393/52559729-7310b880-2e39-11e9-874b-74ec526a5eaa.png)

エラー表示されると"日"がdiv要素の外に出てしまう現象となりました。
デベロッパーツールで確認すると、エラー表示前はdivタグ内に全て格納されていますが、エラー表示後はdivタグの外に出てしまう現象となりました。

対応として、birthday_selectタグにtime要素を追加し、スタイルシートにてtimeにたいしてdisplay:none;とすることで、"日"をコードに追記することでdivタグ内に格納することにしました。
実際に時間要素はデータベースに追加することはありません。

以上、ご確認宜しくお願いします。