### PR TITLE
トップページ、商品SOLD表示

### DIFF
--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -58,6 +58,36 @@
             height: 213px;
             width: 213px;
           }
+          .sold-box{
+            overflow: hidden;
+            position: absolute;
+            width: 100px;
+            height: 100px;
+            &:before {
+              content: '';
+              position: absolute;
+              top: -30px;
+              left: -55px;
+              width: 150px;
+              height: 150px;
+              background: #ea352d;
+              -webkit-transform-origin: left center;
+              -ms-transform-origin: left center;
+              transform-origin: left center;
+              -webkit-transform: rotate(-45deg);
+              -ms-transform: rotate(-45deg);
+              transform: rotate(-45deg);
+              }
+            &__name {
+              position: relative;
+              top: 5px;
+              left: -8px;
+              font-size: 23px;
+              color: #fff;
+              font-weight: 600;
+              transform: rotate(-45deg);
+            }
+          }
         }
         &__body {
           padding: 16px;

--- a/app/views/items/_pickup.haml
+++ b/app/views/items/_pickup.haml
@@ -1,6 +1,9 @@
 %selection.item-box
   = link_to item_path(item) do
     %figure.item-box__photo
+      - if item.buyer_id?
+        .sold-box
+          .sold-box__name SOLD
       = image_tag(item.item_photos.first.photo.to_s, class: "item-box__photo--banner")
     .item-box__body
       %h3.item-box__body--name


### PR DESCRIPTION
# WHAT
トップページ表示商品にSOLD表示を行う。
### app/views/items/_pickup.haml
SOLD記述追加、及びクラス名付与
### app/assets/stylesheets/modules/_index.scss
スタイルシートによる表示を追記。

# WHY
トップページにて売却済み商品に対してSOLD表示が出来るようにしました。
スタイルシートにてSOLD表示ボックスを回転させ、斜めに表示されるようにしました。
sold-boxにoverflow: hidden;とすることで親要素の下に入れ込む形として、表示がはみ出る部分は見えないようにしました。
SOLD表示についても回転させることで斜めに表示出来るようにしてきます。

以上、ご確認宜しくお願いします。

<img width="1001" alt="ab86b3263b9e42486861640d76bfa09f" src="https://user-images.githubusercontent.com/45278393/52691009-e4b84600-2fa2-11e9-8a88-f20df9940124.png">
