### PR TITLE
マイページ内トップ、ユーザー情報の表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,4 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true
   validates :password, length: { in: 6..128 }
   validates :birthday, presence: true
-
-  def saler_items_number(user)
-    return user.items.length - user.scores.length
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,8 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true
   validates :password, length: { in: 6..128 }
   validates :birthday, presence: true
+
+  def saler_items_number(user)
+    return user.items.length - user.scores.length
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :scores
   has_many :likes
-  has_many :items
+  has_many :items, foreign_key: 'saler_id'
   validates :nickname, presence: true
   validates :encrypted_password, presence: true
   validates :last_name, presence: true

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -4,12 +4,17 @@
     %section.container__during--user-box
       = link_to "", class:  "user-link" do
         = image_tag("member_photo_noimage_thumb.png",class: "user-link__image")
-        %h2 鬼束ちひろ
+        %h2
+          = current_user.nickname
         .user-the-history
           %div
-            %span 評価 0
+            %span
+              評価
+              = current_user.scores.length
           %div
-            %span 出品数 0
+            %span
+              出品数
+              = current_user.items.length
     %section.container__during--user-box__todo
       %ul.container__during--user-box__todo-list
         %li

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -14,7 +14,7 @@
           %div
             %span
               出品数
-              = current_user.saler_items_number(current_user)
+              = current_user.items.length
     %section.container__during--user-box__todo
       %ul.container__during--user-box__todo-list
         %li

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -14,7 +14,7 @@
           %div
             %span
               出品数
-              = current_user.items.length
+              = current_user.saler_items_number(current_user)
     %section.container__during--user-box__todo
       %ul.container__during--user-box__todo-list
         %li


### PR DESCRIPTION
# WHAT
マイページ画面にてユーザー情報を表示する。
### app/models/user.rb
itemsのsaler_idを参照してアソシエーションを行う設定を追加。
### app/views/users/index.haml
user,item,scoreテーブルよりデータを参照する形に変更。

# WHY
マイページ内のユーザ情報を仮置きテキストから、データベース参照型に変更しました。
画像については、現時点で参照できる状態となっていない為、別ブランチにて作業します。
・名前はcurrent_user自身の名前を取得しています。
・評価はユーザ評価された総数を取得して反映する形にしています。
・出品数はitem内の出品者idの要素数を取得して表示しています。
出品数は出品総数を表示しています。現在の出品数をだすべきと考えていましたが、出品総数を出力していましたので、removeコミットにて戻しています。

以上ご確認宜しくお願いします。

## 表示イメージ

<img width="726" alt="70c6af9f98a5176e39439e3ba9814043" src="https://user-images.githubusercontent.com/45278393/52708847-843efe00-2fce-11e9-98c5-0c7ae9e82388.png">
