### PR TITLE
商品詳細ページ、データベース情報反映

### DIFF
--- a/app/assets/stylesheets/modules/_item-show.scss
+++ b/app/assets/stylesheets/modules/_item-show.scss
@@ -35,6 +35,36 @@
               width: 300px;
               display:none
             }
+            .sold-box{
+              overflow: hidden;
+              position: absolute;
+              width: 100px;
+              height: 100px;
+              &:before {
+                content: '';
+                position: absolute;
+                top: -30px;
+                left: -55px;
+                width: 150px;
+                height: 150px;
+                background: #ea352d;
+                -webkit-transform-origin: left center;
+                -ms-transform-origin: left center;
+                transform-origin: left center;
+                -webkit-transform: rotate(-45deg);
+                -ms-transform: rotate(-45deg);
+                transform: rotate(-45deg);
+                }
+              &__name {
+                position: relative;
+                top: 5px;
+                left: -8px;
+                font-size: 23px;
+                color: #fff;
+                font-weight: 600;
+                transform: rotate(-45deg);
+              }
+            }
           }
         }
         &-sub {
@@ -92,6 +122,9 @@
       line-height: 56px;
       font-size: 24px;
       font-weight: bold;
+    }
+    .buy-after {
+    background-color: #888;
     }
 
     &-exhibitor-comment {

--- a/app/assets/stylesheets/modules/_item-show.scss
+++ b/app/assets/stylesheets/modules/_item-show.scss
@@ -1,16 +1,3 @@
-body {
-  margin: 0;
-  width: 100%;
-  height: 100%;
-  background-color: #F5F5F5;
-}
-
-ul, li, h1, h2, h3, p {
-  margin: 0;
-  padding: 0;
-}
-
-
 .show-item {
   width: 700px;
   margin: 0 auto;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -37,9 +37,8 @@
       = link_to "", class: "show-item__main-buy-btn" do
         購入画面に進む
 
-    / 出品者のコメント
-    .show-item__main-exhibitor-comment
-      トップスの二枚セット
+    %p.show-item__main-exhibitor-comment
+      = @item.description
     .show-item__main-btn-container
       .show-item__main-btn-container-left
         = link_to "", class: "like" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,14 +9,12 @@
       .item-image
         .item-image-main
           .big-photo-box
-            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big1"
-            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big2"
-            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big3"
-            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big4"
+            - @item.item_photos.each_with_index do |photo, number|
+              = image_tag photo.photo.to_s, class: "bigs", id: "big#{number+1}"
         .item-image-sub
-          - @item.item_photos.each_with_index do |p, i|
+          - @item.item_photos.each_with_index do |photo, number|
             .image-sub
-              =image_tag "items/m22842714743_1.jpg", class: "mini", id: "mini#{i + 1}"
+              = image_tag photo.photo.to_s, class: "mini", id: "mini#{number+1}"
 
       / 出品の詳細テーブル
       .item-detail-table

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,6 +9,9 @@
       .item-image
         .item-image-main
           .big-photo-box
+            - if @item.buyer_id?
+              .sold-box
+                .sold-box__name SOLD
             - @item.item_photos.each_with_index do |photo, number|
               = image_tag photo.photo.to_s, class: "bigs", id: "big#{number+1}"
         .item-image-sub
@@ -27,8 +30,12 @@
         (税込)
         %span.postage
           送料込み
-    = link_to "", class: "show-item__main-buy-btn" do
-      購入画面に進む
+    - if @item.buyer_id?
+      .show-item__main-buy-btn.buy-after
+        売り切れました
+    - else
+      = link_to "", class: "show-item__main-buy-btn" do
+        購入画面に進む
 
     / 出品者のコメント
     .show-item__main-exhibitor-comment


### PR DESCRIPTION
# WHAT
商品詳細ページ、データベース参照による情報表示を実装。

### app/views/items/show.html.haml
商品購入前後のスタイルデータを追加。
仮置き時の不要な設定を削除。
### app/assets/stylesheets/modules/_item-show.scss
写真・商品詳細テキストをデータベースより取得する形に変更。
商品購入ボタンとSOLD表示を条件分岐。

# WHY
商品詳細ページにて、データベースより情報取得ができていなかった点について、データベース参照型に変更を行いました。
・スタイルシートは仮置き時に設定していた全体に対しての要素を削除しました。layoutで同じ要素があるため。
・商品の売買状況に応じた条件分岐を加え、画面表示の変更及び購入後に購入ができないようにしました。
・商品画像について、データベースより情報を取得して表示する形に変更しました。
・商品詳細テキストについて、同様にデータベースから情報を表示出来るようにしました。
商品詳細テキスト表示部より下の画面は今後実装を行います。
商品情報のリンク先については、リンク先ページ作成完了後にページ指定を行います。

以上、ご確認宜しくお願いします。


### 表示イメージ
#### 購入前
<img width="668" alt="c214e86d34cd989f136735739efc0a60" src="https://user-images.githubusercontent.com/45278393/52769279-33cdac00-3073-11e9-80aa-17f89daedd5d.png">

#### 購入後
<img width="688" alt="8bbf8ea31e023f3f14b7d16363898044" src="https://user-images.githubusercontent.com/45278393/52769280-33cdac00-3073-11e9-9a2b-43329abc965e.png">
