### PR TITLE
商品詳細ページ、表示修正

### DIFF
--- a/app/views/items/_item-info.html.haml
+++ b/app/views/items/_item-info.html.haml
@@ -37,7 +37,8 @@
     %th
       商品のサイズ
     %td
-      = @item.size.type_i18n
+      - unless @item.size.nil?
+        = @item.size.type_i18n
   %tr
     %th
       商品の状態

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -30,12 +30,13 @@
         (税込)
         %span.postage
           送料込み
-    - if @item.buyer_id?
-      .show-item__main-buy-btn.buy-after
-        売り切れました
-    - else
-      = link_to "", class: "show-item__main-buy-btn" do
-        購入画面に進む
+    - if @item.saler_id != current_user.id
+      - if @item.buyer_id?
+        .show-item__main-buy-btn.buy-after
+          売り切れました
+      - else
+        = link_to "", class: "show-item__main-buy-btn" do
+          購入画面に進む
 
     %p.show-item__main-exhibitor-comment
       = @item.description


### PR DESCRIPTION
# WHAT
サイズがない場合にエラーとなってしまう修正。
自分が出品した商品を購入できないよう処理分岐を追加。

# WHY
・サイズ指定できない商品がエラーとなる為、商品していがない場合は空欄で表示出来るようにした。
・自分で出品した商品は購入出来ないように、処理分岐することで商品購入ボタンをでないようにした。