### PR TITLE
商品詳細ページ、その他の商品表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "mixin/position";
 @import "mixin/icon";
 @import "mixin/show-items";
+@import "mixin/sold-tag";
 
 @import "modules/top";
 @import "modules/header";

--- a/app/assets/stylesheets/mixin/_sold-tag.scss
+++ b/app/assets/stylesheets/mixin/_sold-tag.scss
@@ -1,0 +1,32 @@
+@mixin sold-tag {
+  .sold-tag {
+    overflow: hidden;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    &:before {
+      content: '';
+      position: absolute;
+      top: -30px;
+      left: -55px;
+      width: 150px;
+      height: 150px;
+      background: #ea352d;
+      -webkit-transform-origin: left center;
+      -ms-transform-origin: left center;
+      transform-origin: left center;
+      -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+      }
+    &__name {
+      position: relative;
+      top: 5px;
+      left: -8px;
+      font-size: 23px;
+      color: #fff;
+      font-weight: 600;
+      transform: rotate(-45deg);
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_item-show.scss
+++ b/app/assets/stylesheets/modules/_item-show.scss
@@ -35,36 +35,7 @@
               width: 300px;
               display:none
             }
-            .sold-box{
-              overflow: hidden;
-              position: absolute;
-              width: 100px;
-              height: 100px;
-              &:before {
-                content: '';
-                position: absolute;
-                top: -30px;
-                left: -55px;
-                width: 150px;
-                height: 150px;
-                background: #ea352d;
-                -webkit-transform-origin: left center;
-                -ms-transform-origin: left center;
-                transform-origin: left center;
-                -webkit-transform: rotate(-45deg);
-                -ms-transform: rotate(-45deg);
-                transform: rotate(-45deg);
-                }
-              &__name {
-                position: relative;
-                top: 5px;
-                left: -8px;
-                font-size: 23px;
-                color: #fff;
-                font-weight: 600;
-                transform: rotate(-45deg);
-              }
-            }
+            @include sold-tag
           }
         }
         &-sub {
@@ -163,24 +134,22 @@
     margin: 8px auto;
     width: 700px;
     background-color: #fff;
-
     &--box {
-
-
       .comment-area {
         padding: 24px;
-
-
         &__list {
+          .image {
+            border-radius: 50%;
+            height: 40px;
+            width: 40px;
+          }
           list-style: none;
           padding: 0;
           margin: 0;
-
           .first-comment {
             margin: 0 1.5rem 0 0;
             @include comment-balloon();
           }
-
           li {
             width: 100%;
             margin: 60px 0 0;
@@ -195,7 +164,6 @@
         width: 650px;
         background-color: #fff6de;
         font-size: 14px;
-
         p {
           line-height: 1.0rem;
           padding: 8px;
@@ -203,14 +171,12 @@
         }
       }
     }
-
     .comment {
       margin-top: 8px;
       padding-left: 5px;
       width: 640px;
       height: 100px;
     }
-
     .comment-btn {
       @include btn();
       height: 50px;
@@ -220,9 +186,7 @@
       font-size: 12px;
       font-weight: bold;
     }
-
   }
-
   .show-item__next {
     height: 50px;
     &-item-left {
@@ -234,14 +198,12 @@
       @include next-item();
     }
   }
-
   .show-item__sns {
     margin-bottom: 24px;
     padding: 32px 0 24px;
     height: 100px;
     width: 100%;
     background-color: #fff;
-
     &-contents {
       padding-top: 40px;
       margin: 0 auto;
@@ -249,13 +211,10 @@
       width: 300px;
       list-style: none;
       text-align: center;
-
-
       .sns-box {
-          display: inline-block;
-          height: 40px;
-          width: 40px;
-
+        display: inline-block;
+        height: 40px;
+        width: 40px;
         &-facebook {
           display: block;
           background-color: #385185;
@@ -271,7 +230,6 @@
             }
           }
         }
-
         &-twitter {
           display: block;
           background-color: #0099e8;
@@ -305,9 +263,11 @@
       }
     }
   }
-
   .other {
     width: 700px;
+    h2 {
+      margin: 24px 0 8px;
+    }
     &-items-title {
       font-size: 22px;
       font-weight: bold;
@@ -318,9 +278,8 @@
       @include clearfix();
       width: 100%;
       margin-bottom: 24px;
-
-      &-item-first {
-        margin: 0 0 20px 0;
+      &-item {
+        margin: 0 0 20px 20px;
         color: #333;
         text-decoration: none;
         background-color: #fff;
@@ -328,6 +287,7 @@
         height: 330px;
         width: 220px;
         &-image {
+          @include sold-tag;
           height: 220px;
           width: 220px;
           .photo {
@@ -356,54 +316,12 @@
               font-size: 6px;
             }
           }
-
         }
-      }
-      &-item {
-        margin: 0 0 20px 20px;
-        color: #333;
-        text-decoration: none;
-        background-color: #fff;
-        float: left;
-        height: 330px;
-        width: 220px;
-        &-image {
-          height: 220px;
-          width: 220px;
-          .photo {
-            height: 220px;
-            width: 220px;
-          }
-        }
-        &-box {
-          padding: 16px;
-          height: 78px;
-          &-title {
-            h3 {
-              @include clearfix();
-                position: relative;
-                font-weight: 400;
-                height: 3em;
-                line-height: 1.5;
-                word-break: break-word;
-                white-space: normal;
-            }
-          }
-          &-price {
-            line-height: 1rem;
-            font-weight: bold;
-            p {
-              font-size: 6px;
-            }
-          }
+        &:nth-child(3n-2) {
+          margin-left: 0;
         }
       }
     }
   }
 }
 
-  .image {
-    border-radius: 50%;
-    height: 40px;
-    width: 40px;
-  }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,8 @@ class ItemsController < ApplicationController
       @categorys.unshift(item_category)
       item_category = Category.find_by(name: item_category.parent_id)
     end
+    @other_user_items = Item.where(saler_id: @item.saler_id).order("id DESC").limit(6)
+    @other_category_items = Item.where(category: @item.category).order("id DESC").limit(6)
   end
 
   def update

--- a/app/views/items/_other-items.html.haml
+++ b/app/views/items/_other-items.html.haml
@@ -1,25 +1,13 @@
-.other-items
-  - for num in 1..2 do
-    = link_to "", class: "other-items-item-first" do
-      .other-items-item-first-image
-        = image_tag "items/m22842714743_1.jpg", class: "photo"
-      .other-items-item-first-box
-        .other-items-item-first-box-title
-          %h3 Tのやつ
-        .other-items-item-first-box-price
-          ¥6,540
-          %br
-          %p (税込)
-    - for num in 1..2 do
-      = link_to "", class: "other-items-item" do
-        .other-items-item-image
-          = image_tag "items/m22842714743_1.jpg", class: "photo"
-        .other-items-item-box
-          .other-items-item-box-title
-            %h3 Tのやつ
-          .other-items-item-box-price
-            ¥6,540
-            %br
-            %p (税込)
-
-
+.other-items-item
+  = link_to item_path(item.id) do
+    .other-items-item-image
+      = render "sold-tag", item: item
+      = image_tag item.item_photos.first.photo.to_s, class: "photo"
+    .other-items-item-box
+      .other-items-item-box-title
+        %h3
+          = item.name
+      .other-items-item-box-price
+        = item.price
+        %br
+        %p (税込)

--- a/app/views/items/_sold-tag.haml
+++ b/app/views/items/_sold-tag.haml
@@ -1,0 +1,3 @@
+- if item.trading > 1
+  .sold-tag
+    .sold-tag__name SOLD

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,9 +9,7 @@
       .item-image
         .item-image-main
           .big-photo-box
-            - if @item.trading > 1
-              .sold-box
-                .sold-box__name SOLD
+            = render "sold-tag", item: @item
             - @item.item_photos.each_with_index do |photo, number|
               = image_tag photo.photo.to_s, class: "bigs", id: "big#{number+1}"
         .item-image-sub
@@ -90,15 +88,15 @@
         .sns-box-pinterest
           = link_to "", class: "pinterest" do
             = fa_icon "pinterest", class: "fa"
-
-  / 出品者のその他の出品リスト
   .other
-    =link_to "", class: "other-items-title" do
-      ちゃあさんのその他の商品
-    = render "items/other-items"
-
-  / ブランドのその他のリスト
+    %h2.other__title
+      = link_to "", class: "other-items-title" do
+        = "#{@item.saler.nickname}さんのその他の商品"
+    .other-items
+      = render partial: "other-items", collection: @other_user_items, as: "item"
   .other
-    =link_to "", class: "other-items-title" do
-      アーバンリサーチのその他の商品
-    = render "items/other-items"
+    %h2.other__title
+      =link_to "", class: "other-items-title" do
+        = "#{@item.category.name_i18n}のその他の商品"
+    .other-items
+      = render partial: "other-items", collection: @other_category_items, as: "item"


### PR DESCRIPTION
# WHAT
商品詳細ページ画面下部「その他の商品」を実装。
### 商品画像左上「SOLD表示」をテンプレート化
app/views/items/_sold-tag.haml
app/assets/stylesheets/mixin/_sold-tag.scss
### スタイルシート、インポート設定追加
app/assets/stylesheets/application.scss
### スタイルシート設定変更
app/assets/stylesheets/modules/_item-show.scss
### 「その他の商品」データベースから取得
app/controllers/items_controller.rb
### 「その他の商品」テンプレート、仮置きデータからデータベース参照へ変更
app/views/items/_other-items.html.haml
### 「その他の商品」ビューを変更
app/views/items/show.html.haml

# WHY
商品詳細ページ画面下部のその他の商品について、データベース参照によるデータ表示を実装しました。

・商品表示について、データベースより最大6件を出力し、部分テンプレートを参照して表示する形としました。スタイルシートについては:nth-child()記述を利用して、marginの使い分けをしています。
・売り切れ時のSOLD表示について、画面上部の商品画像にも同じ出力がある為、部分テンプレートと切り出しを行いました、スタイルシートについてもmixinに変更してコード記述を1箇所に統一しました。

以上、ご確認宜しくお願いします。

## イメージ画像
<img width="1440" alt="2019-02-16 13 51 06" src="https://user-images.githubusercontent.com/45278393/52894711-0e1ae100-31f2-11e9-9006-c141ed3cd857.png">

<img width="1440" alt="2019-02-16 13 51 31" src="https://user-images.githubusercontent.com/45278393/52894710-0d824a80-31f2-11e9-8563-b9e2db7154f6.png">

