### PR TITLE
コメント機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_comment-balloon.scss
+++ b/app/assets/stylesheets/modules/_comment-balloon.scss
@@ -42,9 +42,15 @@
         right: 99%;
         top: 22%;
       }
+      .text {
+        font-size :14px;
+      }
       .icons{
         .clock {
           color: #aaa;
+        }
+        .time {
+          opacity: 0.6;
         }
         .flag {
           color: #aaa;

--- a/app/assets/stylesheets/modules/_item-show.scss
+++ b/app/assets/stylesheets/modules/_item-show.scss
@@ -174,7 +174,8 @@
         &__list {
           list-style: none;
           padding: 0;
-          margin: 0;
+          margin: 0 0 35px 0;
+          // margin: 30px;
 
           .first-comment {
             margin: 0 1.5rem 0 0;
@@ -190,7 +191,8 @@
       }
     }
     .comment-box {
-      padding: 24px;
+      padding: 0 24px 24px 24px ;
+
       .comment-detail {
         width: 650px;
         background-color: #fff6de;
@@ -209,6 +211,7 @@
       padding-left: 5px;
       width: 640px;
       height: 100px;
+      font-size: 16px;
     }
 
     .comment-btn {
@@ -219,6 +222,7 @@
       line-height: 56px;
       font-size: 12px;
       font-weight: bold;
+      width: 650px;
     }
 
   }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,11 @@
+class CommentsController < ApplicationController
+    def create
+      @comment = Comment.create(comment: comment_params[:comment], item_id: comment_params[:item_id], user_id: current_user.id)
+      redirect_to item_path(@comment.item.id)
+    end
+
+    private
+    def comment_params
+      params.permit(:comment, :item_id)
+    end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
     def create
-      @comment = Comment.create(comment: comment_params[:comment], item_id: comment_params[:item_id], user_id: current_user.id)
+      @comment = current_user.comments.create(comment_params)
       redirect_to item_path(@comment.item.id)
     end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    @comments = @item.comments.includes(:user)
     @score = Score.all
     @categorys = []
     item_category = @item.category

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :delivery_fee
   belongs_to :category
   belongs_to :brand ,optional: true
-
+  has_many :comments
   has_many :item_photos
   accepts_nested_attributes_for :item_photos
   has_many :likes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :scores
   has_many :likes
   has_many :items, foreign_key: 'saler_id'
+  has_many :comments
   validates :nickname, presence: true
   validates :encrypted_password, presence: true
   validates :last_name, presence: true

--- a/app/views/items/_comment-box.html.haml
+++ b/app/views/items/_comment-box.html.haml
@@ -1,31 +1,18 @@
 .comment-area
-  %ul.comment-area__list
-    %li.first-comment
-      = link_to "", class: "user-comment__left" do
-        = image_tag "items/922148154.jpg", class: "image"
-      .user-comment-right
-        .username
-          ペンペン
-        .text-box
-          .text
-            キター
-          .icons
-            = fa_icon "clock", class: "clock"
-            %span 10日前
-            = fa_icon "flag", class: "flag"
-
-    - for num in 1..3 do
-      %li
-        = link_to "", class: "user-comment__left" do
-          = image_tag "items/922148154.jpg", class: "image"
-
-        .user-comment-right
-          .username
-            ペンペンペン
-          .text-box
-            .text
-              キター
-            .icons
-              = fa_icon "clock", class: "clock"
-              %span 24日前
-              = fa_icon "flag", class: "flag"
+  - if @comments
+    - @comments.each do |comment|
+      %ul.comment-area__list
+        %li.first-comment
+          = link_to users_path, class: "user-comment__left" do
+            = image_tag "items/922148154.jpg", class: "image"
+          .user-comment-right
+            .username
+              = comment.user.nickname
+            .text-box
+              .text
+                = comment.comment
+              .icons
+                = fa_icon "clock", class: "clock"
+                %span.time
+                  = time_ago_in_words(comment.created_at)
+                  = fa_icon "flag", class: "flag"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -61,13 +61,17 @@
       = render "items/comment-box"
 
       / コメント入力欄
-      .comment-box
-        .comment-detail
-          %p
-            相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-        %textarea.comment
-        = link_to "", class: "comment-btn" do
-          コメントする
+      - if current_user || sns_user
+        = form_with( url: item_comments_path(@item), local: true, method: :post ) do |f|
+          .comment-box
+            .comment-detail
+              %p
+                相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+            = f.text_area :comment, class: 'comment'
+            = f.submit type: "submit", value: "コメントする", class: "comment-btn"
+            / %input{type: "submit", :value => "コメントする", class: "comment-btn"}
+            / = link_to "", class: "comment-btn" do
+
 
   .show-item__next
     = link_to "", class: "show-item__next-item-left" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root 'items#index'
   devise_for :users, controllers: { sessions: 'sessions' ,registrations: "registrations"}
-  resources :items, except: [:edit, :destroy]
+  resources :items, except: [:edit, :destroy] do
+    resources :comments, only: [:create]
+  end
   resources :users do
     collection do
       get "selling"


### PR DESCRIPTION
# what
コメントのルーティングの設定については現在はcreateの機能だけ実装予定のため、onlyのオプションで指定。
関連するアイテムとユーザーのモデルに対してアソシエーションを設定。
コメント機能の実装に付随してhamlとscssの記述を若干変更。
コメントのコントローラーでストロングパラメーターを設定し、createアクションでコメントが保存されるようにしました。

# why
コメントの機能の実装により出品者と購入者とでのアイテム購入に関する取引を円滑にしユーザビリティの向上を測りました。

＃＃pictweetを参考にしコメント機能を実装しましたがcreateアクションの記述が若干長くなってしまいました。もう少し簡略化できるようであれば教えていただけると助かります。
よろしくお願いします。