### PR TITLE
ユーザー新規登録ページ、バリデーション設定

### DIFF
--- a/app/assets/javascripts/validates.js
+++ b/app/assets/javascripts/validates.js
@@ -1,0 +1,50 @@
+$(function(){
+  function error_message(error_message, error_msg_box) {
+    var messages = {
+      "nickname": "ニックネームを入力してください",
+      "email": "メールアドレスを入力してください",
+      "password": "パスワードを入力してください",
+      "password_confirmation": "パスワード (確認)を入力してください",
+      "last_name": "姓 (全角)を入力してください",
+      "first_name": "名 (全角)を入力してください",
+      "last_name_kana": "姓カナ (全角)を入力してください",
+      "first_name_kana": "名カナ (全角)を入力してください"
+    }
+    $.each(messages,function(err_name, text){
+      if (error_message == err_name) {
+        error_msg_box.text(text);
+      }
+    })
+  }
+  $(".field").on("keyup", function(){
+    var input_field_parent = $(this).parent();
+    if (input_field_parent.attr("class") == "field_with_errors") {
+      var input_field_parent = $(input_field_parent).parent();
+    }
+    var input_filed_boxs = input_field_parent.children();
+    input_filed_boxs.each(function(){
+      if ($(this).attr("class") == "span error-msg") {
+        $(this).remove();
+      }
+    });
+    input_field_parent.append(`<div class="span error-msg"></div>`);
+    var error_msg_box = input_field_parent.children().last();
+    if ($(this).val().length == 0 ) {
+      var error_name = $(this).attr("name");
+      var error_RegExp = RegExp(/\[(.*)\]/);
+      var err_message = error_name.match(error_RegExp)[1];
+      error_message(err_message, error_msg_box);
+    } else {
+      error_msg_box.text("");
+    }
+  });
+  $('select').change(function() {
+    var birthday_year = $('[name="user[birthday(1i)]"] option:selected').text();
+    var birthday_month = $('[name="user[birthday(2i)]"] option:selected').text();
+    var birthday_date = $('[name="user[birthday(3i)]"] option:selected').text();
+    var err_msg = $('.birthday-select .error-msg');
+    if ((err_msg.text.length > 0) && (birthday_year > 0) && (birthday_month > 0) && (birthday_date > 0)) {
+      err_msg.empty();
+    }
+  })
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,15 @@ class User < ApplicationRecord
   has_many :scores
   has_many :likes
   has_many :items, foreign_key: 'saler_id'
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_KANA_REGEX = /[ァ-ヴ][ァ-ヴー・]*/
   validates :nickname, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :encrypted_password, presence: true
   validates :last_name, presence: true
   validates :first_name, presence: true
-  validates :last_name_kana, presence: true
-  validates :first_name_kana, presence: true
-  validates :password, length: { in: 6..128 }
+  validates :last_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "カナで入力してください。" }
+  validates :first_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "カナで入力してください。" }
+  validates :password, length: { in: 6..128, message: "パスワードは6文字以上128文字以下で入力してください" }
   validates :birthday, presence: true
 end


### PR DESCRIPTION
# WHAT
ユーザーモデルにバリデーション設定追加及び、ユーザ新規登録ページでのエラーメッセージ表示操作を実装。
### バリデーション設定の追加
app/models/user.rb
### JQueryによるエラーメッセージ表示・非表示設定を追加
app/assets/javascripts/validates.js

# WHY
1.ユーザモデルに対するバリデーションに関して、設定内容を追加しました。
2.ユーザ新規登録時のエラーメッセージをJQueryを利用して、動的に表示出来るように実装しました。

## 1.バリデーションについて
メールアドレスについて、正規表現によるメールアドレス判定を追加しました。
姓名カナ入力文字について、正規表現によるカナ判定を追加し、エラーメッセージも変更しました。
パスワードについて、追加でエラーメッセージ内容を変更しました。
### バリデーション表示イメージ(計2枚)
#### 1
![6f9eb908b9de73e049f0a844b5eb6ca9](https://user-images.githubusercontent.com/45278393/52912565-5a4f4980-32f6-11e9-8759-3a76232da1c1.png)
#### 2
![db9d0509ae7fa034dc77628ff34be528](https://user-images.githubusercontent.com/45278393/52912566-5ae7e000-32f6-11e9-94d1-d224b4be8183.png)

## 2.JQueryによるエラーメッセージ動的表示について
・Inputエリア
バリデーションによるエラー表示後、ユーザーが入力を行うことで各エラーメッセージが消去されるようにしました。
始めに新規登録画面に遷移した場合と、バリデーションエラー表示後でエラー表示を行うクラス(field_with_errors,error-msgなど)が含まれる場合があるので、どちらにも対応できるようにifによる処理分岐をしました。
具体的には、エラークラスがある場合は一度消去を行い、改めてエラークラスを作成しています。バリデーションによるエラー表示が複数になる場合があるので、このような処理としました。
入力開始後、再度input欄の内容が消去されると、エラーメッセージが表示されるようにしています。
JQueryによる動的なエラーメッセージ表示は、JSファイルに記載したメッセージから表示するようにしました。
・Selectエリア
生年月日のエラーメッセージについては、バリデーションで表示された後、3項目全て選択すると消去することにしました。
### 新規登録JQueryイメージ(計4枚)
#### 1
![46120b43f78be951c4a70a306dc1b373](https://user-images.githubusercontent.com/45278393/52912605-e6617100-32f6-11e9-94a5-63804bc384f4.gif)
#### 2
![46120b43f78be951c4a70a306dc1b373](https://user-images.githubusercontent.com/45278393/52912631-5112ac80-32f7-11e9-8657-2bcb1864ab31.gif)
#### 3
![03ccd4aba37e145324d35da44efb14f3](https://user-images.githubusercontent.com/45278393/52912633-54a63380-32f7-11e9-8e06-d1efb740c4a7.gif)
#### 4
![2c07f04d9cff0fe089fdc78b3a263526](https://user-images.githubusercontent.com/45278393/52912646-9931cf00-32f7-11e9-9ee4-8423492aa0f1.gif)



以上、ご確認宜しくお願いします。
