### PR TITLE
デプロイ環境設定

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,8 @@
 lock "~> 3.11.0"
 
 set :application, "freemarket_sample_43b"
-set :repo_url, "git@github.com:yuu0919/freemarket_sample_43b.git"
+# set :repo_url, "git@github.com:yuu0919/freemarket_sample_43b.git"
+set :repo_url, ENV["REPOSITORY_GIT_URL"]
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 
@@ -10,7 +11,8 @@ set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'
 
 set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/test.pem']
+                  # keys: ['~/.ssh/test.pem']
+                  keys: ENV["ACCESS_KEY_PEM"]
 
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,7 +60,8 @@
 #     # password: "please use keys"
 #   }
 
-server "52.198.40.158", user: 'ec2-user', roles: %w{app db web}
+# server "52.198.40.158", user: 'ec2-user', roles: %w{app db web}
+server ENV["REPOSITORY_ELASTIC_IP"], user: 'ec2-user', roles: %w{app db web}
 
 set :rails_env, "production"
 set :unicorn_rack_env, "production"

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,8 @@ CarrierWave.configure do |config|
   if Rails.env.development? || Rails.env.test?
     config.storage = :file
   elsif Rails.env.production?
-    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket-sample-43b'
+    # config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket-sample-43b'
+    config.asset_host = ENV["S3_BUCKET_ADDRESS"]
     config.storage = :fog
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
@@ -16,5 +17,6 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1'
     }
   end
-  config.fog_directory  = 'freemarket-sample-43b'
+  # config.fog_directory  = 'freemarket-sample-43b'
+  config.fog_directory  = ENV["S3_BUCKET_NAME"]
 end


### PR DESCRIPTION
# WHAT
デプロイ設定情報を環境設定ファイル参照型へ変更。

# WHY
デプロイ者毎のカスタム情報を有効にするため

問題発生時に元の環境に戻すため、一端コメントアウトで旧設定を保持。