### PR TITLE
マイページ商品状況確認

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,15 +23,15 @@ class UsersController < ApplicationController
   end
 
   def complete
-    @items = Item.where(trading: "3").order(id: "DESC")
+    @items = Item.where(trading: "3", saler_id: current_user.id).order(id: "DESC")
   end
 
   def purchase
-    @items = Item.where(trading: "2").order(id: "DESC")
+    @items = Item.where(trading: "2", buyer_id: current_user.id).order(id: "DESC")
   end
 
   def purchased
-    @items = Item.where(trading: "3").order(id: "DESC")
+    @items = Item.where(trading: "3", buyer_id: current_user.id).order(id: "DESC")
   end
 
   def logout

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,11 +15,11 @@ class UsersController < ApplicationController
   end
 
   def selling
-    @items = Item.where(trading: "1").order(id: "DESC")
+    @items = Item.where(trading: "1", saler_id: current_user.id).order(id: "DESC")
   end
 
   def progress
-    @items = Item.where(trading: "2").order(id: "DESC")
+    @items = Item.where(trading: "2", saler_id: current_user.id).order(id: "DESC")
   end
 
   def complete


### PR DESCRIPTION
# WHAT
マイページ内の商品取引状況確認画面の編集。

# WHY
全ユーザの商品が表示されていた為、対象ユーザの取引状況のみ表示する方法に変更。