### PR TITLE
出品商品削除機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,4 +50,4 @@
 @import "user_edit";
 @import "modules/app-banner";
 @import "modules/footer";
-
+@import "modules/item-edit";

--- a/app/assets/stylesheets/modules/_item-edit.scss
+++ b/app/assets/stylesheets/modules/_item-edit.scss
@@ -1,18 +1,18 @@
 .button-list {
-  margin: 24px 0 24px 0;
-  background-color:#fff;
+  margin: 24px 0;
+  background-color: #fff;
   width: 100%;
   padding: 15px 0;
   &__edit {
     background: #ea352d;
     color: #fff;
-    width:90%;
+    width: 90%;
     display: block;
     line-height: 48px;
     font-size: 14px;
     border: 1px solid transparent;
     text-align: center;
-    margin-left:35px;
+    margin-left: 35px;
   }
   &__center {
     text-align: center;
@@ -31,15 +31,15 @@
     display: block;
   }
   &__delite {
-  background: #aaa;
-  color: #fff;
-  width:90%;
-  border: 1px solid #ea352d;
-  display: block;
-  line-height: 48px;
-  font-size: 14px;
-  border: 1px solid transparent;
-  text-align: center;
-  margin-left:35px;
+    background: #aaa;
+    color: #fff;
+    width: 90%;
+    border: 1px solid #ea352d;
+    display: block;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    text-align: center;
+    margin-left: 35px;
   }
 }

--- a/app/assets/stylesheets/modules/_item-edit.scss
+++ b/app/assets/stylesheets/modules/_item-edit.scss
@@ -1,0 +1,45 @@
+.button-list {
+  margin: 24px 0 24px 0;
+  background-color:#fff;
+  width: 100%;
+  padding: 15px 0;
+  &__edit {
+    background: #ea352d;
+    color: #fff;
+    width:90%;
+    display: block;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    text-align: center;
+    margin-left:35px;
+  }
+  &__center {
+    text-align: center;
+    margin: 15px 0 ;
+    font-size: 1.2rem;
+  }
+  &__stop {
+    width:90%;
+    line-height: 48px;
+    font-size: 14px;
+    text-align: center;
+    background: #aaa;
+    border: 1px solid #aaa;
+    color: #fff;
+    margin: 0 0 13px 35px;
+    display: block;
+  }
+  &__delite {
+  background: #aaa;
+  color: #fff;
+  width:90%;
+  border: 1px solid #ea352d;
+  display: block;
+  line-height: 48px;
+  font-size: 14px;
+  border: 1px solid transparent;
+  text-align: center;
+  margin-left:35px;
+  }
+}

--- a/app/assets/stylesheets/modules/_item-edit.scss
+++ b/app/assets/stylesheets/modules/_item-edit.scss
@@ -16,11 +16,11 @@
   }
   &__center {
     text-align: center;
-    margin: 15px 0 ;
+    margin: 15px 0;
     font-size: 1.2rem;
   }
   &__stop {
-    width:90%;
+    width: 90%;
     line-height: 48px;
     font-size: 14px;
     text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :get_item, only: [:show, :destroy]
   layout  "session", except: [:index, :show]
   layout false, only: [:search]
 
@@ -19,7 +20,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     @comments = @item.comments.includes(:user)
     saler = @item.saler_id
     @score = Score.where(user_id: saler)
@@ -34,6 +34,13 @@ class ItemsController < ApplicationController
   end
 
   def update
+  end
+
+  def destroy
+    if @item.saler_id == (current_user.id || sns_user.id)
+      @item.destroy
+    end
+    redirect_to :selling_users
   end
 
   def search
@@ -64,5 +71,9 @@ class ItemsController < ApplicationController
     brand = Brand.find_by(name: params[:item][:brand_name])
     brand_id = (brand.present?) ? (brand.id) : nil
     params.require(:item).permit(:name, :price, :description, :category_id, :shipping_date_id, :condition_id, :region_id, :delivery_fee_id, :ship_method_id, :brand_id, :size_id, item_photos_attributes: [:id, :photo]).merge(saler_id: current_user.id, brand_id: brand_id)
+  end
+
+  def get_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,10 +7,10 @@ class Item < ApplicationRecord
   belongs_to :delivery_fee
   belongs_to :category
   belongs_to :brand ,optional: true
-  has_many :comments
-  has_many :item_photos
+  has_many :comments, dependent: :destroy
+  has_many :item_photos, dependent: :destroy
   accepts_nested_attributes_for :item_photos
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :snslikes
   has_many :snscredential
 

--- a/app/views/items/_add-comment.haml
+++ b/app/views/items/_add-comment.haml
@@ -1,0 +1,7 @@
+= form_with( url: item_comments_path(@item), local: true, method: :post ) do |f|
+  .comment-box
+    .comment-detail
+      %p
+        相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+    = f.text_area :comment, class: 'comment'
+    = f.submit type: "submit", value: "コメントする", class: "comment-btn"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,7 +8,7 @@
     .show-item__main--content
       .item-image
         .item-image-main
-          .big-photo-box 
+          .big-photo-box
             - if @item.trading > 1
               .sold-box
                 .sold-box__name SOLD
@@ -52,21 +52,31 @@
       = link_to "", class: "show-item__main-btn-container-right" do
         = fa_icon "lock", class: ""
         %span あんしん・あんぜんへの取り組み
-
-  / ユーザー間のコメント一覧
-  .show-item__user-comment
-    .show-item__user-comment--box
-      = render "items/comment-box"
-
-      / コメント入力欄
-      - if current_user || sns_user
-        = form_with( url: item_comments_path(@item), local: true, method: :post ) do |f|
-          .comment-box
-            .comment-detail
-              %p
-                相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-            = f.text_area :comment, class: 'comment'
-            = f.submit type: "submit", value: "コメントする", class: "comment-btn"
+  - if (current_user || sns_user) && (current_user.id || sns_user.id) == @item.saler_id
+    .button-list
+      = link_to "商品の編集","", class: "button-list__edit"
+      %p.button-list__center or
+      = link_to "出品を一旦停止する","", class: "button-list__stop"
+      = link_to "この商品を削除する", "/items/#{@item.id}", class: "button-list__delite test-popup-link", method: :delete, data: { confirm: '削除すると二度と復活できません。本当に削除しますか？' }
+    .show-item__user-comment
+      .show-item__user-comment--box
+        = render "items/comment-box"
+        = render "items/add-comment"
+  - elsif current_user || sns_user
+    .show-item__user-comment
+      .show-item__user-comment--box
+        = render "items/comment-box"
+        = render "items/add-comment"
+  - elsif @comments.length >= 1
+    .show-item__user-comment
+      .show-item__user-comment--box
+        = render "items/comment-box"
+  .show-item__next
+    = link_to "", class: "show-item__next-item-left" do
+      < ネイル用品
+    = link_to "", class: "show-item__next-item-right" do
+      amiibo アミーボ splatoon トリプルセット >
+>>>>>>> origin/master
 
   / SNSボタンの欄
   .show-item__sns

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'items#index'
   devise_for :users, controllers: { sessions: 'sessions' ,registrations: "registrations"}
-  resources :items, except: [:edit, :destroy] do
+  resources :items, except: [:edit] do
     resources :likes, only: [:create, :destroy]
     resources :comments, only: [:create]
     resources :scores, only:[:new, :create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_02_19_022139) do
+
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -116,10 +117,8 @@ ActiveRecord::Schema.define(version: 2019_02_19_022139) do
   create_table "scores", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "type", null: false
     t.bigint "user_id"
-    t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_scores_on_item_id"
     t.index ["user_id"], name: "index_scores_on_user_id"
   end
 
@@ -194,7 +193,6 @@ ActiveRecord::Schema.define(version: 2019_02_19_022139) do
   add_foreign_key "items", "sizes"
   add_foreign_key "likes", "items"
   add_foreign_key "likes", "users"
-  add_foreign_key "scores", "items"
   add_foreign_key "scores", "users"
   add_foreign_key "snslikes", "items"
   add_foreign_key "snslikes", "snscredentials"


### PR DESCRIPTION
# what
商品を削除するためのボタンの一覧を作成し、削除ボタンを押した際にアラートを表示し削除が本当にされても良いのかをユーザーに伝える。
削除後は商品一覧のページへリダイレクトするように実装しました。

# why
今回商品一覧ページを実装するにあたり状況によってはログイン状況等によって詳細ページでの変化があったため合わせて実装しました。

deviseかsnsのどちらかでログインしており、アイテムと紐づくdeviseもしくはsnsユーザーのidがitemの出品者のidが一致する場合
・ボタンリスト
・コメント一覧
・コメント入力フィールド

deviseかsnsのどちらかでログインしている場合
コメント一覧
コメント入力フィールド

コメントが１件以上ある場合
コメント一覧

上記の内容で条件分岐を設定しました。

本来はif文を一度だけ記述し内部で条件を分けて実装がしたかったのですがインデントをずらすとビューの表示が崩れてしまうため、同じ記述を複数記述するような実装をしています。
可読性が低くなること、無駄に行数が増えてしまうことを避けるためにコメント入力のところは部分テンプレートを実装し対応しています。
##
削除機能を実装するにあたり外部キー制約の働きによりエラーとなる問題があったため、itemモデルにdeleteを許可する記述をしています。
##
削除確認についてはlinkにオプションでアラートを出現させるように記述しています。
##
削除実装動画
https://gyazo.com/c9935cce16b25009008dde629d28298d