### PR TITLE
商品詳細ページ、画像表示修正

### DIFF
--- a/app/assets/stylesheets/modules/item/_item-show.scss
+++ b/app/assets/stylesheets/modules/item/_item-show.scss
@@ -21,6 +21,7 @@
           height: 300px;
           width: 300px;
           .big-photo-box {
+            overflow: hidden;
             display: flex;
             #big1 {
               height: 300px;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,7 +7,6 @@
       .item-image
         .item-image-main
           .big-photo-box
-          .big-photo-box
             = render "sold-tag", item: @item
             - @item.item_photos.each_with_index do |photo, number|
               = image_tag photo.photo.to_s, class: "bigs", id: "big#{number+1}"


### PR DESCRIPTION
# WHAT
商品画像表示スクロールにおいてカーソル移動後に次の画像が右側に表示されてしまう問題があるため、修正を実施。

# WHY
不必要な表示をしないようにする為