### PR TITLE
いいね機能リファクタリング

### DIFF
--- a/app/assets/stylesheets/modules/item/_item-show.scss
+++ b/app/assets/stylesheets/modules/item/_item-show.scss
@@ -55,17 +55,14 @@
           }
         }
       }
-
       .item-detail-table {
         float: right;
         width: 300px;
-
         table {
           @include table();
         }
       }
     }
-
     &-price {
       font-size: 50px;
       font-weight: bold;
@@ -93,23 +90,21 @@
     .buy-after {
     background-color: #888;
     }
-
     &-exhibitor-comment {
       padding: 32px 0 0;
       word-break: break-all;
     }
-
     &-btn-container {
       @include clearfix();
       margin: 16px 0 0;
-
       &-left {
+        .btn-likes {
         border-radius: 40px;
         float: left;
-        .like {
-          @include mini-btn();
+          .like {
+            @include mini-btn();
+          }
         }
-
         .report {
           margin-left: 16px;
           @include mini-btn();
@@ -124,9 +119,7 @@
       }
     }
   }
-
   &__user-comment {
-
     margin: 8px auto;
     width: 700px;
     background-color: #fff;
@@ -156,7 +149,6 @@
     }
     .comment-box {
       padding: 0 24px 24px 24px ;
-
       .comment-detail {
         width: 650px;
         background-color: #fff6de;
@@ -184,17 +176,6 @@
       font-size: 12px;
       font-weight: bold;
       width: 650px;
-    }
-  }
-  .show-item__next {
-    height: 50px;
-    &-item-left {
-      float: left;
-      @include next-item();
-    }
-    &-item-right {
-      float: right;
-      @include next-item();
     }
   }
   .show-item__sns {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,15 +3,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :get_category, :get_brand
   helper_method :sns_user
-  helper_method :totals
   layout :layout_by_resource
-
-  def totals
-    item = @item
-    like = Like.where(item_id: item)
-    snslike = Snslike.where(item_id: item)
-    total = like.length + snslike.length
-  end
 
   def get_category
     @category_roots = Category.roots.includes(:children)

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,38 +1,19 @@
 class LikesController < ApplicationController
-  before_action :set_item , only: [:create, :destroy]
-  layout false, only: [:create, :destroy]
+  before_action :set_item
+  layout false
 
   def create
-    if current_user
-      @like = current_user.likes.create(item_id: params[:item_id])
-      respond_to do |format|
-        format.html
-        format.js
-      end
-    else
-      @like = sns_user.snslikes.create(item_id: params[:item_id])
-      respond_to do |format|
-        format.html
-        format.js
-      end
+    like = current_user.likes.create(item_id: params[:item_id])
+    respond_to do |format|
+      format.js
     end
   end
 
   def destroy
-    if current_user
-      like = current_user.likes.find_by(item_id: params[:item_id])
-      like.destroy
-      respond_to do |format|
-        format.html
-        format.js
-      end
-    else
-      like = sns_user.snslikes.find_by(item_id: params[:item_id])
-      like.destroy
-      respond_to do |format|
-        format.html
-        format.js
-      end
+    like = current_user.likes.find_by(item_id: params[:item_id])
+    like.destroy
+    respond_to do |format|
+      format.js
     end
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,7 +32,7 @@
     %p.show-item__main-exhibitor-comment
       = @item.description
     .show-item__main-btn-container
-      #like-link-item.id.show-item__main-btn-container-left
+      .show-item__main-btn-container-left
         = render partial: 'likes/like', locals:{ item: @item }
         = link_to "", class: "report" do
           = fa_icon "flag", class: ""

--- a/app/views/likes/_like.haml
+++ b/app/views/likes/_like.haml
@@ -1,28 +1,18 @@
-- if user_signed_in?
-  - if item.like_user(current_user.id)
-    = link_to item_like_path(item, item.like_user(current_user)),method: :delete ,remote: true, class: "like" do
-      = fa_icon "heart", class: "heart"
-      %span いいね
-      = totals
+.btn-likes
+  - if user_signed_in?
+    - if item.like_user(current_user)
+      = link_to item_like_path(item, item.like_user(current_user)),method: :delete ,remote: true, class: "like" do
+        = fa_icon "heart", class: "heart"
+        %span いいね
+        = item.likes.length
+    - else
+      = link_to item_likes_path(item),method: :post, remote: true, class: "like" do
+        = fa_icon "heart"
+        %span いいね
+        = item.likes.length
   - else
-    = link_to item_likes_path(item),method: :post, remote: true ,class: "like" do
-      = fa_icon "heart", class: ""
+    = link_to new_user_session_path, class: "like" do
+      = fa_icon "heart"
       %span いいね
-      = totals
-- elsif sns_user
-  - if item.like_sns(sns_user.id)
-    = link_to item_like_path(item, item.like_sns(sns_user)),method: :delete ,remote: true, class: "like" do
-      = fa_icon "heart", class: "heart"
-      %span いいね
-      = totals
-  - else
-    = link_to item_likes_path(item),method: :post, remote: true ,class: "like" do
-      = fa_icon "heart", class: ""
-      %span いいね
-      = totals
-- else
-  = link_to item_likes_path(item),method: :post, remote: true ,class: "like" do
-    = fa_icon "heart", class: "heart"
-    %span いいね
-    = totals
+      = item.likes.length
 

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,1 +1,1 @@
-$("#like-link-item.id.show-item__main-btn-container-left").html('<%= j( render partial: 'likes/like', locals:{ item: @item }) %><a class="report"><i class="fa fa-flag "></i><span> 不適切な商品の報告</span></a>');
+$(".btn-likes").html(`<%= j( render partial: 'likes/like', locals:{ item: @item }) %>`);

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,1 +1,1 @@
-$("#like-link-item.id.show-item__main-btn-container-left").html('<%= j(render partial: 'likes/like', locals:{ item: @item }) %><a class="report"><i class="fa fa-flag "></i><span> 不適切な商品の報告</span></a>');
+$(".btn-likes").html(`<%= j( render partial: 'likes/like', locals:{ item: @item }) %>`);


### PR DESCRIPTION
# WHAT
いいね機能についてリファクタリングを行う。
### ヘルパーメソッド"totals"削除
app/controllers/application_controller.rb
### コントローラ設定、ifによる条件分岐を削除、only設定削除
app/controllers/likes_controller.rb
### showビュー、idを削除
app/views/items/show.html.haml
### いいね機能部分テンプレート、条件分岐削減、リンク先変更
app/views/likes/_like.haml
### 記述変更にともなうスタイル変更
app/assets/stylesheets/modules/item/_item-show.scss
### JS、idセレクタからクラスセレクタへ変更、書き換え範囲変更
app/views/likes/create.js.erb
app/views/likes/destroy.js.erb

# WHY
## userテーブル統一に伴う対応
・deviseログインユーザとsnsログインユーザをuserテーブル一つで管理出来るようにしたことにより、テーブルが一つに統一されたので、snsuser対応コードを削除。
・各テーブルのいいねの合計をだす必要がなくなったので、totalヘルパーメソッドを削除。
## リファクタリング
・「いいねボタン」と「不適切な商品の報告」の2つのボタンを常に書き換えていたので、「いいねボタン」のみに変更
・未ログイン時のいいねボタンのリンク先がitem_likes_pathになっていた為、new_user_session_pathへ変更。
・likes_controllerにonly:[:create, :destroy]の記述があるが、そもそもこの2つしかアクションがないため設定不要であり、削除を実施。
