### PR TITLE
個人情報登録

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import "modules/whole/bread-crumbs";
 @import "modules/whole/like";
 @import "modules/whole/logo-layout";
+@import "modules/user/entry-box";
 @import "modules/user/users";
 @import "modules/user/user_side_bar";
 @import "modules/user/user_edit";

--- a/app/assets/stylesheets/mixin/_progress-bar.scss
+++ b/app/assets/stylesheets/mixin/_progress-bar.scss
@@ -5,41 +5,13 @@
     vertical-align: top;
     .clearfix {
       @include clearfix();
-      .active {
-        margin: 0 40px 0 0;
-        font-size: 12px;
-        font-weight: 600;
-        color: #ea352d;
-        position: relative;
-        z-index: 1;
-        display: inline-block;
-        .progress-status {
-          border-radius: 50%;
-          background: #ea352d;
-          z-index: 3;
-          width: 12px;
-          height: 12px;
-          margin: 8px auto 0;
-          &:after {
-            position: absolute;
-            bottom: 5px;
-            z-index: -1;
-            display: block;
-            content: '';
-            width: 100%;
-            height: 2px;
-            background: #ccc;
-          }
-        }
-      }
-      .inactive {
+      .point {
         margin: 0 40px 0 0;
         font-size: 12px;
         color: #888;
         position: relative;
         z-index: 1;
         display: inline-block;
-
         .progress-status {
           border-radius: 50%;
           background: #ccc;
@@ -69,31 +41,32 @@
             background: #ccc;
           }
         }
-      }
-      .last {
-        margin: 0 40px 0 0;
-        font-size: 12px;
-        color: #888;
-        position: relative;
-        z-index: 1;
-        display: inline-block;
-        .progress-status {
-          border-radius: 50%;
-          background: #ccc;
-          width: 12px;
-          height: 12px;
-          margin: 8px auto 0;
-          &:before {
-            right: 60%;
-            position: absolute;
-            bottom: 5px;
-            z-index: -1;
-            display: block;
-            content: '';
-            width: 100%;
-            height: 2px;
-            background: #ccc;
+        &.active {
+          color: #ea352d;
+          font-weight: 600;
+          .progress-status {
+            background: #ea352d;
           }
+        }
+        &.first {
+          .progress-status {
+            &:before {
+              display: none;
+            }
+          }
+        }
+        &.last {
+          .progress-status {
+            &:before {
+              right: 60%;
+            }
+            &:after {
+              display: none;
+            }
+          }
+        }
+        &.unknown {
+          display: none;
         }
       }
     }

--- a/app/assets/stylesheets/modules/user/_entry-box.scss
+++ b/app/assets/stylesheets/modules/user/_entry-box.scss
@@ -198,6 +198,13 @@
             }
           }
         }
+        .last-message {
+          text-align: center;
+          span {
+            font-size: 18px;
+            line-height: 30px;
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/modules/user/_entry-box.scss
+++ b/app/assets/stylesheets/modules/user/_entry-box.scss
@@ -29,15 +29,20 @@
             font-weight: 600;
             display: inline-block;
           }
-          .require-tag {
+          .label-tag {
             @include f-left;
-            background-color: #ea352d;
             margin: 0 0 0 8px;
             padding: 2px 4px;
             border-radius: 2px;
             color: #fff;
             font-size: 12px;
             vertical-align: top;
+            &.require {
+              background-color: #ea352d;
+            }
+            &.option {
+              background-color: #ccc;
+            }
           }
           .field {
             height: 36px;
@@ -139,6 +144,11 @@
             }
             span {
             }
+          }
+          input[type=number]::-webkit-inner-spin-button,
+          input[type=number]::-webkit-outer-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
           }
           &__info {
             margin: 8px 0 0;

--- a/app/assets/stylesheets/modules/user/_entry-box.scss
+++ b/app/assets/stylesheets/modules/user/_entry-box.scss
@@ -1,0 +1,194 @@
+.entry-box {
+  &__box {
+    background-color: #fff;
+    width: 700px;
+    margin: 0 auto;
+    h1 {
+      padding: 32px 16px;
+      font-size: 22px;
+      text-align: center;
+      font-weight: bold;
+    }
+    &--form {
+      border-top: 1px solid #f5f5f5;
+      padding: 64px;
+      .content {
+        &:first-child {
+          width: 320px;
+          margin: 0 auto;
+        }
+        width: 320px;
+        margin: 50px auto 0;
+        .form-group {
+          margin: 40px 0 0;
+          &:first-child {
+            margin: 0;
+          }
+          label {
+            @include f-left;
+            font-weight: 600;
+            display: inline-block;
+          }
+          .require-tag {
+            @include f-left;
+            background-color: #ea352d;
+            margin: 0 0 0 8px;
+            padding: 2px 4px;
+            border-radius: 2px;
+            color: #fff;
+            font-size: 12px;
+            vertical-align: top;
+          }
+          .field {
+            height: 36px;
+            width: 100%;
+            margin: 8px 0 0;
+            padding: 6px 16px 6px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+            background: #fff;
+            line-height: 1.5;
+            font-size: 16px;
+          }
+          h2 {
+            font-weight: bold;
+            font-size: 16px;
+          }
+          p {
+            margin: 8px 0 0;
+          }
+          .birthday-select {
+            width: 200px;
+            .select-wrap {
+              display: inline-block;
+              position: relative;
+              margin: 8px 0 0;
+              width: 200px;
+              .field_with_errors {
+                .birthday {
+                  border: 1px solid red;
+                }
+              }
+              .birthday {
+                margin-top: 5px;
+                width: 140px;
+                position: relative;
+                z-index: 2;
+                height: 48px;
+                padding: 0 16px;
+                border-radius: 4px;
+                border: 1px solid #ccc;
+                background: 0;
+                font-size: 16px;
+                line-height: 1.5;
+                cursor: pointer;
+                &:nth-child(4){
+                  display: none;
+                }
+                &:nth-child(5){
+                  display: none;
+                }
+              }
+              &__default {
+                width: 140px;
+                position: relative;
+                z-index: 2;
+                height: 48px;
+                padding: 0 16px;
+                border-radius: 4px;
+                border: 1px solid #ccc;
+                background: 0;
+                font-size: 16px;
+                line-height: 1.5;
+                cursor: pointer;
+              }
+              select {
+                outline: 0;
+                -webkit-appearance: none;
+              }
+              #down1 {
+                @include fa-icon();
+                position: absolute;
+                right: 70px;
+                top: 18%;
+                z-index: 2;
+                color: #888;
+                font-size: 28px;
+                transform: translate(0, -50%);
+              }
+              #down2 {
+                @include fa-icon();
+                position: absolute;
+                right: 70px;
+                top: 50%;
+                z-index: 2;
+                color: #888;
+                font-size: 28px;
+                transform: translate(0, -50%);
+              }
+              #down3 {
+                @include fa-icon();
+                position: absolute;
+                right: 70px;
+                top: 82%;
+                z-index: 2;
+                color: #888;
+                font-size: 28px;
+                transform: translate(0, -50%);
+              }
+            }
+            span {
+            }
+          }
+          &__info {
+            margin: 8px 0 0;
+            line-height: 1.5;
+            color: #888;
+          }
+          .recaptcha {
+            height: 78px;
+            width: 320px;
+            border: 1px solid #eee;
+            background-color: #f5f5f5;
+          }
+          &__text {
+            text-align: center;
+            .link {
+              color: #0099e8;
+            }
+          }
+          .error-msg {
+            color: red;
+            margin-top: 8px;
+          }
+          .field_with_errors {
+            input {
+              border: 1px solid red;
+            }
+          }
+        }
+        .btn-next {
+          @include btn();
+          margin: 40px 0 0;
+          background: #ea352d;
+          border: 1px solid #ea352d;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          cursor: pointer;
+        }
+        .text-info {
+          text-align: right;
+          .link {
+            color: #0099e8;
+            .arrow-right {
+              font-size: 16px;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,6 +58,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_sign_up_path_for(resource)
   #   super(resource)
   # end
+  def after_sign_up_path_for(resource)
+    user_profile_path(resource)
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :purchase_data, only: [:index, :purchase]
   before_action :trading_status, except: [:new, :edit, :show, :logout]
   before_action :get_profile, only: [:profile, :entry]
-  layout "logo-layout", only: [:new, :profile]
+  layout "logo-layout", only: [:new, :profile, :entry]
 
   def index
     @select_page = "progress"
@@ -33,9 +33,7 @@ class UsersController < ApplicationController
 
   def entry
     if current_user.id == @profile.user_id
-      if @profile.update(profile_params)
-        redirect_to root_path
-      else
+      unless @profile.update(profile_params)
         render "profile"
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :selection_page, only: [:selling, :purchase]
   before_action :purchase_data, only: [:index, :purchase]
   before_action :trading_status, except: [:new, :edit, :show, :logout]
+  before_action :get_profile, only: [:profile, :entry]
   layout "logo-layout", only: [:new]
 
   def index
@@ -27,6 +28,16 @@ class UsersController < ApplicationController
   def purchase
   end
 
+  def profile
+  end
+
+  def entry
+    if current_user.id == @profile.user_id
+      @profile.update(profile_params)
+      redirect_to root_path
+    end
+  end
+
   def logout
   end
 
@@ -42,5 +53,13 @@ class UsersController < ApplicationController
   def purchase_data
     @purchase = Item.item_buyer_list(trading_status[:progress], current_user.id)
     @purchased = Item.item_buyer_list(trading_status[:complete], current_user.id)
+  end
+
+  def get_profile
+    @profile = current_user.profile
+  end
+
+  def profile_params
+    params.require(:profile).permit(:postal_code, :prefecture, :city, :number, :building)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :purchase_data, only: [:index, :purchase]
   before_action :trading_status, except: [:new, :edit, :show, :logout]
   before_action :get_profile, only: [:profile, :entry]
-  layout "logo-layout", only: [:new]
+  layout "logo-layout", only: [:new, :profile]
 
   def index
     @select_page = "progress"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,8 +33,11 @@ class UsersController < ApplicationController
 
   def entry
     if current_user.id == @profile.user_id
-      @profile.update(profile_params)
-      redirect_to root_path
+      if @profile.update(profile_params)
+        redirect_to root_path
+      else
+        render "profile"
+      end
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,4 +6,10 @@ class Profile < ApplicationRecord
   validates :last_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
   validates :first_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
   validates :birthday, presence: true
+  with_options on: :update do
+    validates :postal_code, presence: true, numericality: true, length: { in: 1..7 }
+    validates :prefecture, presence: true
+    validates :city, presence: true
+    validates :number, presence: true
+  end
 end

--- a/app/views/layouts/logo-layout.haml
+++ b/app/views/layouts/logo-layout.haml
@@ -51,6 +51,24 @@
               %li.point.last
                 完了
                 .progress-status
+        - elsif controller_name == "users" && action_name == "entry"
+          %nav.progress-bar
+            %ol.clearfix
+              %li.point.first
+                会員情報
+                .progress-status
+              %li.point.unknown
+                電話番号認証
+                .progress-status
+              %li.point
+                お届け先住所入力
+                .progress-status
+              %li.point.unknown
+                支払い方法
+                .progress-status
+              %li.point.last.active
+                完了
+                .progress-status
       = yield
       .container__logo-layout--footer
         %nav

--- a/app/views/layouts/logo-layout.haml
+++ b/app/views/layouts/logo-layout.haml
@@ -18,19 +18,37 @@
         - if controller_name == "registrations" && action_name == "new"
           %nav.progress-bar
             %ol.clearfix
-              %li.active
+              %li.point.first.active
                 会員情報
                 .progress-status
-              %li.inactive
+              %li.point.unknown
                 電話番号認証
                 .progress-status
-              %li.inactive
+              %li.point
                 お届け先住所入力
                 .progress-status
-              %li.inactive
+              %li.point.unknown
                 支払い方法
                 .progress-status
-              %li.last
+              %li.point.last
+                完了
+                .progress-status
+        - elsif controller_name == "users" && action_name == "profile"
+          %nav.progress-bar
+            %ol.clearfix
+              %li.point.first
+                会員情報
+                .progress-status
+              %li.point.unknown
+                電話番号認証
+                .progress-status
+              %li.point.active
+                お届け先住所入力
+                .progress-status
+              %li.point.unknown
+                支払い方法
+                .progress-status
+              %li.point.last
                 完了
                 .progress-status
       = yield

--- a/app/views/users/entry.haml
+++ b/app/views/users/entry.haml
@@ -1,0 +1,11 @@
+.entry-box
+  .entry-box__box
+    %h1 会員登録完了
+    .entry-box__box--form
+      .content
+        .last-message
+          %span
+            ありがとうございます。
+            %br
+            会員登録が完了しました。
+        = link_to "メルカリをはじめる。", root_path, class: "btn-next"

--- a/app/views/users/profile.haml
+++ b/app/views/users/profile.haml
@@ -5,35 +5,35 @@
       .content
         .form-group
           = form.label :postal_code
-          %span.require-tag 必須
-          = form.text_field :postal_code, autofocus: true, placeholder: "郵便番号",class: "field"
+          %span.label-tag.require 必須
+          = form.number_field :postal_code, autofocus: true, placeholder: "郵便番号(ハイフンなし)",class: "field", maxlength: 7
           - @profile.errors.full_messages_for(:postal_code).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :prefecture
-          %span.require-tag 必須
+          %span.label-tag.require 必須
           = form.text_field :prefecture, autofocus: true, placeholder: "都道府県",class: "field"
           - @profile.errors.full_messages_for(:prefecture).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :city
-          %span.require-tag 必須
+          %span.label-tag.require 必須
           = form.text_field :city, autofocus: true, placeholder: "市区町村",class: "field"
           - @profile.errors.full_messages_for(:city).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :number
-          %span.require-tag 必須
+          %span.label-tag.require 必須
           = form.text_field :number, autofocus: true, placeholder: "番地",class: "field"
           - @profile.errors.full_messages_for(:number).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :building
-          %span.require-tag 必須
+          %span.label-tag.option 任意
           = form.text_field :building, autofocus: true, placeholder: "建物名",class: "field"
           - @profile.errors.full_messages_for(:building).each do |error|
             .span.error-msg

--- a/app/views/users/profile.haml
+++ b/app/views/users/profile.haml
@@ -6,35 +6,35 @@
         .form-group
           = form.label :postal_code
           %span.require-tag 必須
-          = form.text_field :postal_code, autofocus: true, placeholder: "postal_code",class: "field"
+          = form.text_field :postal_code, autofocus: true, placeholder: "郵便番号",class: "field"
           - @profile.errors.full_messages_for(:postal_code).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :prefecture
           %span.require-tag 必須
-          = form.text_field :prefecture, autofocus: true, placeholder: "prefecture",class: "field"
+          = form.text_field :prefecture, autofocus: true, placeholder: "都道府県",class: "field"
           - @profile.errors.full_messages_for(:prefecture).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :city
           %span.require-tag 必須
-          = form.text_field :city, autofocus: true, placeholder: "city",class: "field"
+          = form.text_field :city, autofocus: true, placeholder: "市区町村",class: "field"
           - @profile.errors.full_messages_for(:city).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :number
           %span.require-tag 必須
-          = form.text_field :number, autofocus: true, placeholder: "number",class: "field"
+          = form.text_field :number, autofocus: true, placeholder: "番地",class: "field"
           - @profile.errors.full_messages_for(:number).each do |error|
             .span.error-msg
               = error
         .form-group
           = form.label :building
           %span.require-tag 必須
-          = form.text_field :building, autofocus: true, placeholder: "building",class: "field"
+          = form.text_field :building, autofocus: true, placeholder: "建物名",class: "field"
           - @profile.errors.full_messages_for(:building).each do |error|
             .span.error-msg
               = error

--- a/app/views/users/profile.haml
+++ b/app/views/users/profile.haml
@@ -1,0 +1,49 @@
+.entry-box
+  .entry-box__box
+    %h1 個人情報入力
+    = form_with(model: @profile, url: user_entry_path, local: true, class: "entry-box__box--form") do |form|
+      .content
+        .form-group
+          = form.label :postal_code
+          %span.require-tag 必須
+          = form.text_field :postal_code, autofocus: true, placeholder: "postal_code",class: "field"
+          - @profile.errors.full_messages_for(:postal_code).each do |error|
+            .span.error-msg
+              = error
+        .form-group
+          = form.label :prefecture
+          %span.require-tag 必須
+          = form.text_field :prefecture, autofocus: true, placeholder: "prefecture",class: "field"
+          - @profile.errors.full_messages_for(:prefecture).each do |error|
+            .span.error-msg
+              = error
+        .form-group
+          = form.label :city
+          %span.require-tag 必須
+          = form.text_field :city, autofocus: true, placeholder: "city",class: "field"
+          - @profile.errors.full_messages_for(:city).each do |error|
+            .span.error-msg
+              = error
+        .form-group
+          = form.label :number
+          %span.require-tag 必須
+          = form.text_field :number, autofocus: true, placeholder: "number",class: "field"
+          - @profile.errors.full_messages_for(:number).each do |error|
+            .span.error-msg
+              = error
+        .form-group
+          = form.label :building
+          %span.require-tag 必須
+          = form.text_field :building, autofocus: true, placeholder: "building",class: "field"
+          - @profile.errors.full_messages_for(:building).each do |error|
+            .span.error-msg
+              = error
+        %p.form-group__info
+          ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+      .content
+        = form.submit("次へ進む", class: "btn-next")
+        .form-group.text-info
+          %p
+            = link_to "", class: "link" do
+              本人情報の登録について
+              = fa_icon "angle-right", class: "arrow-right"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1359,6 +1359,11 @@ ja:
         last_name_kana: 姓カナ (全角)
         first_name_kana: 名カナ (全角)
         birthday: 生年月日
+        postal_code: 郵便番号
+        prefecture: 都道府県
+        city: 市区町村
+        number: 番地
+        building: 建物名
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
       get "purchase"
       get "logout"
     end
+    get "profile"
+    patch "entry"
   end
   get 'auth/:provider/callback', to: 'googles#create'
   get 'signout', to: 'googles#destroy'


### PR DESCRIPTION
# WHAT
新規登録時の個人情報登録を実装。
Deviseによる新規登録実施後、個人情報登録ページに遷移し、個人情報登録実施できるようにする。

### スタイルシート、インポート設定
app/assets/stylesheets/application.scss
### 会員登録progress-barデザイン、リファクタリング
app/assets/stylesheets/mixin/_progress-bar.scss
### 住所登録ページ、スタイルシート
app/assets/stylesheets/modules/user/_entry-box.scss
### コントローラ、メールアドレス登録後のページ遷移先変更
app/controllers/users/registrations_controller.rb
### コントローラ、レイアウト適用設定変更、新規アクション追加
app/controllers/users_controller.rb
### モデル、バリデーション設定追加
app/models/profile.rb
### 会員登録progress-bar、パターン追加とクラス名変更
app/views/layouts/logo-layout.haml
### 会員登録完了ビュー追加
app/views/users/entry.haml
### 住所情報登録ビュー追加
app/views/users/profile.haml
### 住所登録ビュー対応テキスト日本語化
config/locales/ja.yml
### 住所登録・登録完了ページのルーティング追加
config/routes.rb

# WHY
メールアドレス等の登録完了後に住所情報登録ページに遷移し、住所情報登録後に登録完了画面が表示されるようにした。
## 本プルリクエストでは記述の都合上、下記のページ番号を使用する。
P1.メールアドレスによるユーザ登録ページ
P2.電話番号登録ページ(現在未作成)
P3.住所情報登録ページ
P4.クレジットカード登録ページ(現在未作成)
P5.登録完了ページ
## バリデーションについて
・プロフィールモデルにバリデーションを追加したが、P1登録完了時に住所関連のバリデーションによって登録NGとなる為、今回追加したバリデーションはP3登録時のみ適用されるようにupdate実施時のみ動作するようにした。
・P3住所情報登録はP1登録完了時に名前等がプロフィールテーブルにすでに保存されており、同じプロフィールテーブルに登録する為、アップデートとして登録する仕様となっている。
・郵便番号については数字のみ、1〜7文字以内としている。
・建物名等は必要ない場合がある為、任意登録としている。
## ルーティングについて
・住所登録については、P1登録完了後に発行される新規user.idに紐付く為、userにネストさせてprofile,entryアクションを作成している。
・プロフィールテーブルはuserとprofileのhas_oneの関係性となっている。
・プロフィール登録については、プロフィール登録のみ実施するので、userとネストすることなくプロフィールテーブル更新のみとしている。
## progress-barについて
・P1画面の仕様として作成しており、常にP1がアクティブとなっていた為、他のページにも使えるように形と色でクラス名を分ける形に変更。
・activeクラスに対して色・文字を変更することでページ遷移状況が分かるようにした。
・将来的に全ページを作成することを考慮し、クラス名付与で現在存在しないP2P4のポイントを非表示化した。
## その他
P3P5の作成にあたり、P1をベースとして作成している。
クラス名がメールアドレスページに特化していた為、名前を変更しているが、別途P1もクラス名を変更することでスタイルシートを一本化し、不要なファイルの削除をしたい。本作業とは異なる内容となる為、未実施。
SNSログインについても、新規登録時はP3以降の対応が必要となるため、実装を予定。