### PR TITLE
SNS新規登録・ログイン処理

### DIFF
--- a/app/assets/stylesheets/modules/user/_registration-select.scss
+++ b/app/assets/stylesheets/modules/user/_registration-select.scss
@@ -64,6 +64,11 @@
             font-size: 20px;
           }
         }
+        .alert {
+          text-align: center;
+          padding: 10px;
+          color: red;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/modules/user/_session.scss
+++ b/app/assets/stylesheets/modules/user/_session.scss
@@ -51,6 +51,11 @@
           font-size: 20px;
         }
       }
+      .alert {
+        text-align: center;
+        padding: 10px;
+        color: red;
+      }
     }
     .login-form {
       &__inner {

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -45,12 +45,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.find_for_oauth(request.env['omniauth.auth'], $select_page)
 
     if @user == false
-      redirect_to $select_page
+      if $select_page.match(/sign_in/)
+        errmsg = "未登録です。新規登録して下さい。"
+      else
+        errmsg = "登録済みです。ログインして下さい。"
+      end
+      redirect_to $select_page, flash: {error: errmsg}
     else
       if @user.new_record?
         @user.build_profile.created_at = Date.today.to_time
         @user.save(context: :created_at)
-        binding.pry
       end
       sign_in_and_redirect @user, event: :authentication
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,11 +1,13 @@
 class Profile < ApplicationRecord
   belongs_to :user
   VALID_KANA_REGEX = /[ァ-ヴ][ァ-ヴー・]*/
-  validates :last_name, presence: true
-  validates :first_name, presence: true
-  validates :last_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
-  validates :first_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
-  validates :birthday, presence: true
+  with_options unless: :created_at do |omniauth|
+    omniauth.validates :last_name, presence: true
+    omniauth.validates :first_name, presence: true
+    omniauth.validates :last_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
+    omniauth.validates :first_name_kana, presence: true, format: { with: VALID_KANA_REGEX , message: "は「カナ」で入力してください。" }
+    omniauth.validates :birthday, presence: true
+  end
   with_options on: :update do
     validates :postal_code, presence: true, numericality: true, length: { in: 1..7 }
     validates :prefecture, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,20 +14,29 @@ class User < ApplicationRecord
   validates :encrypted_password, presence: true
   validates :password, length: { in: 6..128, message: "パスワードは6文字以上128文字以下で入力してください" }
 
-  def self.find_for_oauth(auth)
+  def self.find_for_oauth(auth, select)
     user = User.where(uid: auth.uid, provider: auth.provider).first
-
-    unless user
-      user = User.create(
-        uid:      auth.uid,
-        provider: auth.provider,
-        email:    User.dummy_email(auth),
-        password: Devise.friendly_token[0, 20],
-        nickname: auth.info.name
-      )
+    if select.match(/new/)
+      if user
+        return false
+      else
+        user = User.new(
+          uid:      auth.uid,
+          provider: auth.provider,
+          email:    User.dummy_email(auth),
+          password: Devise.friendly_token[0, 20],
+          nickname: auth.info.name
+        )
+      end
+    elsif select.match(/sign_in/)
+      if user
+        return user
+      else
+        return false
+      end
+    else
+      return false
     end
-
-    user
   end
 
   private

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -7,6 +7,9 @@
     .session
       = link_to "Facebookログイン", user_facebook_omniauth_authorize_path, class: "session-facebook"
       = link_to "Googleログイン",  user_google_oauth2_omniauth_authorize_path,class: "session-google"
+      - if flash[:error]
+        .alert
+          = flash[:error]
     = form_with(model: @user, url: new_user_session_path, method: :post, local: true, class: "login-form") do |form|
       .login-form__inner
         .form-column

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -6,7 +6,7 @@
         新規会員登録
     .session
       = link_to "Facebookログイン", user_facebook_omniauth_authorize_path, class: "session-facebook"
-      = link_to "Googleログイン",  user_google_oauth2_omniauth_authorize_path,class: "session-google"
+      = link_to "Googleログイン", user_google_oauth2_omniauth_authorize_path,class: "session-google"
       - if flash[:error]
         .alert
           = flash[:error]

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -6,7 +6,7 @@
         = link_to new_user_registration_path, class: "mail" do
           メールアドレスで登録
           = fa_icon "envelope", class: "mail-icon"
-        = link_to "", class: "facebook" do
+        = link_to user_facebook_omniauth_authorize_path, class: "facebook" do
           Facebookで登録
           = fa_icon "facebook-square", class: "facebook-icon"
         = link_to "", class: "google" do

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -12,3 +12,6 @@
         = link_to "", class: "google" do
           Googleで登録
           = fa_icon "google-plus-g", class: "google-icon"
+        - if flash[:error]
+          .alert
+            = flash[:error]

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -9,7 +9,7 @@
         = link_to user_facebook_omniauth_authorize_path, class: "facebook" do
           Facebookで登録
           = fa_icon "facebook-square", class: "facebook-icon"
-        = link_to "", class: "google" do
+        = link_to user_google_oauth2_omniauth_authorize_path, class: "google" do
           Googleで登録
           = fa_icon "google-plus-g", class: "google-icon"
         - if flash[:error]


### PR DESCRIPTION
# WHAT
SNSログイン機能を利用して、新規登録時は登録フォーマットへ遷移。ログイン時はログイン処理へと分岐させる。
### スタイルシート、フラッシュメッセージ対応
app/assets/stylesheets/modules/user/_registration-select.scss
app/assets/stylesheets/modules/user/_session.scss
### コントローラ、新規登録時、ログイン時の処理分岐を追加
app/controllers/users/omniauth_callbacks_controller.rb
### モデルprofile、deviseログイン・SNS新規でバリデーションパターン分岐処理
app/models/profile.rb
### モデルuser、ユーザ処理分岐を追加
app/models/user.rb
### ビュー、フラッシュメッセージ対応、omniauth向けリンクパス追加
app/views/devise/sessions/new.haml
app/views/users/new.haml

# WHY
SNS利用による新規登録及びログイン時の処理分岐を実装。
未登録時にリンククリックで登録処理＋ログインを実施、登録済みの時は自動的にログインとなり、新規と既存ユーザの分岐処理がなかった為、分岐処理を追加。
## 動作
新規登録ボタン＋未登録→uidを登録して次の個人情報を登録画面へ遷移
新規登録ボタン＋登録済→登録済みのアラート表示してリダイレクト
ログインボタン＋未登録→未登録アラートを表示してリダイレクト
ログインボタン＋登録済→ログインしてトップページにリダイレクト
アラート時はフラッシュメッセージで内容を表示するようにした。
## omniauth_callbacks_controllerによる処理について
select_page(処理を開始したリンクボタン配置ページ)をsign_in_and_redirectによるページ遷移時に引数として加えてリダイレクト先を変更したかったが、実装できなかった為、グローバル変数として宣言し、リダイレクト時の処理に使用。
## 新規作成ユーザに関して
2テーブル同時保存の一時対応機能を追加。
deviseによる新規作成時にuser,profileの2テーブルに同時に保存する仕様としているが、snsユーザの新規作成時にはprofileテーブルへの保存項目がない状態となっている。
このまま次のprofile登録ページに遷移すると、userテーブルに対応するprofileテーブルが作成されていない状態となり、@profileが存在しないエラーとなってしまう。
対応として、userテーブル新規登録時にprofileテーブルにcreated_atを現時刻で作成するレコードを追加して、初期登録時に2テーブル保存を実現した。
