### PR TITLE
本番環境フェイスブック認証設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -287,7 +287,7 @@ Devise.setup do |config|
   # ActiveSupport.on_load(:devise_failure_app) do
   #   include Turbolinks::Controller
   # end
-  config.omniauth :facebook, ENV['FACEBOOK_ID'], ENV['FACEBOOK_SECRET']
+  config.omniauth :facebook, ENV['FACEBOOK_ID'], ENV['FACEBOOK_SECRET'],token_params: { parse: :json }
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
 end
 


### PR DESCRIPTION
# WHAT
本番環境でフェイスブック認証する為の設定変更

# WHY
本番環境設定に必要な設定があった為、追加実装を実施